### PR TITLE
Retry apt actions if we fail to get an apt lock

### DIFF
--- a/apt-update/tasks/main.yml
+++ b/apt-update/tasks/main.yml
@@ -5,3 +5,6 @@
     name: "*"
     update_cache: yes
     state: latest
+  register: apt_action
+  retries: 100
+  until: apt_action is success or ('Failed to lock apt for exclusive operation' not in apt_action.msg and '/var/lib/dpkg/lock' not in apt_action.msg)

--- a/awscli/tasks/main.yml
+++ b/awscli/tasks/main.yml
@@ -6,3 +6,6 @@
       - awscli
     state: present
     update_cache: yes
+  register: apt_action
+  retries: 100
+  until: apt_action is success or ('Failed to lock apt for exclusive operation' not in apt_action.msg and '/var/lib/dpkg/lock' not in apt_action.msg)

--- a/chia-blockchain/tasks/main.yml
+++ b/chia-blockchain/tasks/main.yml
@@ -7,6 +7,9 @@
       - python3-dev
       - build-essential
     state: present
+  register: apt_action
+  retries: 100
+  until: apt_action is success or ('Failed to lock apt for exclusive operation' not in apt_action.msg and '/var/lib/dpkg/lock' not in apt_action.msg)
 
 - name: Ensure chia directories exist
   # become, in case ownership is incorrect

--- a/consul/tasks/main.yml
+++ b/consul/tasks/main.yml
@@ -5,6 +5,9 @@
     update_cache: yes
     state: present
   notify: restart-consul
+  register: apt_action
+  retries: 100
+  until: apt_action is success or ('Failed to lock apt for exclusive operation' not in apt_action.msg and '/var/lib/dpkg/lock' not in apt_action.msg)
 
 - name: Distribute Certificates
   ansible.builtin.copy:

--- a/disable-resolvd/tasks/main.yml
+++ b/disable-resolvd/tasks/main.yml
@@ -5,16 +5,19 @@
     path: "/etc/hosts"
     regexp: '^127.0.0.1 localhost'
     line: "127.0.0.1 localhost {{ ansible_facts.hostname }}"
+
 - name: Copy updated config into place
   become: yes
   template:
     src: resolved.conf
     dest: /etc/systemd/resolved.conf
+
 - name: Copy resolv.conf into place
   become: yes
   template:
     src: resolv.conf
     dest: /etc/resolv.conf
+
 - name: Stop and disable resolved service
   become: yes
   ansible.builtin.systemd:

--- a/dns-introducer/meta/main.yml
+++ b/dns-introducer/meta/main.yml
@@ -1,3 +1,4 @@
 ---
 dependencies:
+  - role: git
   - role: disable-resolvd

--- a/dns-introducer/tasks/main.yaml
+++ b/dns-introducer/tasks/main.yaml
@@ -1,11 +1,4 @@
 ---
-- name: Install Deps
-  become: yes
-  ansible.builtin.apt:
-    name:
-      - git
-    state: present
-
 - name: Ensure chia directories exist
   # become, in case ownership is incorrect
   become: yes

--- a/git/tasks/main.yml
+++ b/git/tasks/main.yml
@@ -6,3 +6,6 @@
       - git
     update_cache: yes
     cache_valid_time: 3600
+  register: apt_action
+  retries: 100
+  until: apt_action is success or ('Failed to lock apt for exclusive operation' not in apt_action.msg and '/var/lib/dpkg/lock' not in apt_action.msg)

--- a/nginx/tasks/main.yml
+++ b/nginx/tasks/main.yml
@@ -5,6 +5,10 @@
     name:
       - nginx
     state: present
+  register: apt_action
+  retries: 100
+  until: apt_action is success or ('Failed to lock apt for exclusive operation' not in apt_action.msg and '/var/lib/dpkg/lock' not in apt_action.msg)
+
 - name: Ensure service is in desired boot and current state
   become: yes
   ansible.builtin.systemd:

--- a/prometheus-node-exporter/tasks/main.yml
+++ b/prometheus-node-exporter/tasks/main.yml
@@ -5,6 +5,9 @@
     name:
       - prometheus-node-exporter
     state: present
+  register: apt_action
+  retries: 100
+  until: apt_action is success or ('Failed to lock apt for exclusive operation' not in apt_action.msg and '/var/lib/dpkg/lock' not in apt_action.msg)
 
 - name: Ensure service is in desired boot and current state
   become: yes

--- a/python/tasks/main.yml
+++ b/python/tasks/main.yml
@@ -7,3 +7,6 @@
       - python3.8-distutils
     update_cache: yes
     cache_valid_time: 3600
+  register: apt_action
+  retries: 100
+  until: apt_action is success or ('Failed to lock apt for exclusive operation' not in apt_action.msg and '/var/lib/dpkg/lock' not in apt_action.msg)

--- a/sqlite3/tasks/main.yml
+++ b/sqlite3/tasks/main.yml
@@ -6,3 +6,6 @@
       - sqlite3
     state: present
     update_cache: yes
+  register: apt_action
+  retries: 100
+  until: apt_action is success or ('Failed to lock apt for exclusive operation' not in apt_action.msg and '/var/lib/dpkg/lock' not in apt_action.msg)

--- a/unattended-upgrades/tasks/main.yml
+++ b/unattended-upgrades/tasks/main.yml
@@ -9,3 +9,6 @@
     name:
       - unattended-upgrades
     state: absent
+  register: apt_action
+  retries: 100
+  until: apt_action is success or ('Failed to lock apt for exclusive operation' not in apt_action.msg and '/var/lib/dpkg/lock' not in apt_action.msg)

--- a/vault/tasks/main.yml
+++ b/vault/tasks/main.yml
@@ -5,6 +5,9 @@
     update_cache: yes
     state: present
   notify: restart-vault
+  register: apt_action
+  retries: 100
+  until: apt_action is success or ('Failed to lock apt for exclusive operation' not in apt_action.msg and '/var/lib/dpkg/lock' not in apt_action.msg)
 
 - name: Template vault config
   ansible.builtin.template:

--- a/vector/tasks/main.yml
+++ b/vector/tasks/main.yml
@@ -16,6 +16,9 @@
     update_cache: yes
     state: present
   notify: restart-vector
+  register: apt_action
+  retries: 100
+  until: apt_action is success or ('Failed to lock apt for exclusive operation' not in apt_action.msg and '/var/lib/dpkg/lock' not in apt_action.msg)
 
 - name: Template vector config
   template:


### PR DESCRIPTION
Sometimes apt tasks fail because apt is locked by an autoupdate or by a race condition on a thread - this retries until the lock is released