### PR TITLE
Add chia-exporter role

### DIFF
--- a/chia-exporter/defaults/main.yml
+++ b/chia-exporter/defaults/main.yml
@@ -5,3 +5,13 @@ chia_exporter_start_now: yes
 
 user: ubuntu
 group: ubuntu
+
+chia_root: "/home/ubuntu/.chia"
+
+# You can use a username/PAT here or an oauth Key/Secret to get around the anonymous rate limits
+# Link: https://docs.github.com/en/rest/overview/resources-in-the-rest-api#oauth2-keysecret
+github_username: ""
+github_password: ""
+
+# Arch Specific Vars - These are set in vars/$arch.yml
+download_arch: ""

--- a/chia-exporter/defaults/main.yml
+++ b/chia-exporter/defaults/main.yml
@@ -6,6 +6,8 @@ chia_exporter_start_now: yes
 user: ubuntu
 group: ubuntu
 
+# This variable name + default needs to be kept in sync with the chia-blockchain role so that these roles are
+# compatible when used in the same playbook / on the same host
 chia_root: "/home/ubuntu/.chia"
 
 # You can use a username/PAT here or an oauth Key/Secret to get around the anonymous rate limits

--- a/chia-exporter/defaults/main.yml
+++ b/chia-exporter/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+chia_exporter_service_name: chia-exporter.service
+chia_exporter_start_on_boot: yes
+chia_exporter_start_now: yes
+
+user: ubuntu
+group: ubuntu

--- a/chia-exporter/handlers/main.yml
+++ b/chia-exporter/handlers/main.yml
@@ -1,0 +1,6 @@
+- name: restart-chia-exporter
+  become: yes
+  service:
+    name: "{{ chia_exporter_service_name }}"
+    state: restarted
+  when: chia_exporter_start_now

--- a/chia-exporter/tasks/main.yml
+++ b/chia-exporter/tasks/main.yml
@@ -1,9 +1,18 @@
 ---
+- name: Load architecture specific vars
+  include_vars: "{{ lookup('first_found', params) }}"
+  vars:
+    params:
+      files:
+        - '{{ansible_architecture}}.yml'
+      paths:
+        - 'vars'
+
 - name: Install Deps
   become: yes
   ansible.builtin.apt:
     name:
-      - jq
+      - unzip
     state: present
     update_cache: yes
     cache_valid_time: 300
@@ -26,14 +35,40 @@
   uri:
     url: https://api.github.com/repos/Chia-Network/chia-exporter/releases/latest
     return_content: true
+    force_basic_auth: true
+    url_username: "{{ github_username }}"
+    url_password: "{{ github_password }}"
   register: json_response
 
 - name: Get latest chia-exporter release
   become: yes
   get_url:
-    url: "{{ json_reponse.json.assets.[?name=='chia-exporter-linux-arm64.zip'].browser_download_url }}"
+    url: "{{ json_response.json | json_query(latest_url_query) | first }}"
+    dest: "/home/{{ user }}/bin/chia-exporter-{{ json_response.json.tag_name }}.zip"
+  vars:
+    - latest_url_query: "assets[?name=='chia-exporter-linux-{{ download_arch }}.zip'].browser_download_url"
+  notify: restart-chia-exporter
+  register: new_release
+
+- name: Unzip the new release
+  ansible.builtin.unarchive:
+    src: "/home/{{ user }}/bin/chia-exporter-{{ json_response.json.tag_name }}.zip"
     dest: "/home/{{ user }}/bin"
-    mode: '0750'
+    remote_src: true
+  when: new_release.changed
+
+- name: Move the binary into the correct location
+  ansible.builtin.copy:
+    src: "/home/{{ user }}/bin/chia-exporter-linux-{{ download_arch }}/chia-exporter"
+    dest: "/home/{{ user }}/bin/chia-exporter"
+    remote_src: true
+    mode: 0755
+  when: new_release.changed
+
+- name: Ensure the extracted folder is not present
+  file:
+    path: "/home/{{ user }}/bin/chia-exporter-linux-{{ download_arch }}"
+    state: absent
 
 - name: Chia Exporter Systemd Config
   become: yes

--- a/chia-exporter/tasks/main.yml
+++ b/chia-exporter/tasks/main.yml
@@ -1,0 +1,53 @@
+---
+- name: Install Deps
+  become: yes
+  ansible.builtin.apt:
+    name:
+      - jq
+    state: present
+    update_cache: yes
+    cache_valid_time: 300
+  register: apt_action
+  retries: 100
+  until: apt_action is success or ('Failed to lock apt for exclusive operation' not in apt_action.msg and '/var/lib/dpkg/lock' not in apt_action.msg)
+
+- name: Ensure bin directory exists
+  become: yes
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ user }}"
+    group: "{{ group }}"
+    recurse: yes
+  with_items:
+    - "/home/{{ user }}/bin"
+
+- name: Determine the latest chia-exporter release file
+  uri:
+    url: https://api.github.com/repos/Chia-Network/chia-exporter/releases/latest
+    return_content: true
+  register: json_response
+
+- name: Get latest chia-exporter release
+  become: yes
+  get_url:
+    url: "{{ json_reponse.json.assets.[?name=='chia-exporter-linux-arm64.zip'].browser_download_url }}"
+    dest: "/home/{{ user }}/bin"
+    mode: '0750'
+
+- name: Chia Exporter Systemd Config
+  become: yes
+  ansible.builtin.template:
+    src: "chia-exporter.service.j2"
+    dest: "/etc/systemd/system/{{ chia_exporter_service_name }}"
+    owner: root
+    group: root
+  notify: restart-chia-exporter
+
+- name: Ensure chia-exporter service is in desired boot and current state
+  become: yes
+  ansible.builtin.systemd:
+    name: "{{ chia_exporter_service_name }}"
+    daemon_reload: yes
+    enabled: "{{ chia_exporter_start_on_boot }}"
+    state: "{{ chia_exporter_start_now | ternary('started','stopped') }}"

--- a/chia-exporter/templates/chia-exporter.service.j2
+++ b/chia-exporter/templates/chia-exporter.service.j2
@@ -3,7 +3,8 @@ Description=Chia Exporter Service for {{ user }}
 
 [Service]
 Type=simple
-ExecStart=/home/{{ user }}/bin/chia-exporter
+Environment=CHIA_ROOT={{ chia_root }}
+ExecStart=/home/{{ user }}/bin/chia-exporter serve
 User={{ user }}
 Group={{ group }}
 

--- a/chia-exporter/templates/chia-exporter.service.j2
+++ b/chia-exporter/templates/chia-exporter.service.j2
@@ -1,0 +1,11 @@
+[Unit]
+Description=Chia Exporter Service for {{ user }}
+
+[Service]
+Type=simple
+ExecStart=/home/{{ user }}/bin/chia-exporter
+User={{ user }}
+Group={{ group }}
+
+[Install]
+WantedBy=multi-user.target

--- a/chia-exporter/vars/aarch64.yml
+++ b/chia-exporter/vars/aarch64.yml
@@ -1,0 +1,2 @@
+---
+download_arch: "arm64"

--- a/chia-exporter/vars/x86_64.yml
+++ b/chia-exporter/vars/x86_64.yml
@@ -1,0 +1,2 @@
+---
+download_arch: "amd64"


### PR DESCRIPTION
Determines the latest release of https://github.com/Chia-Network/chia-exporter, downloads it to the host if the version isn't present, and configures it to run w/ systemd