### PR TITLE
Update backup + db-pull scripts to not wait on chia-exporter

### DIFF
--- a/blockchain-backup/templates/backup.sh.j2
+++ b/blockchain-backup/templates/backup.sh.j2
@@ -35,7 +35,7 @@ sudo systemctl stop chia
 
 count=1
 while :; do
-	processes=$(ps -aux | grep chia | grep -v grep | wc -l)
+	processes=$(ps -aux | grep chia | grep -v grep | grep -v chia-exporter | wc -l)
 	echo "found $processes running chia processes. Waiting for all processes to stop..."
 
 	# Exit conditions

--- a/db-pull-on-boot/templates/db-pull.sh.j2
+++ b/db-pull-on-boot/templates/db-pull.sh.j2
@@ -24,7 +24,7 @@ sudo systemctl stop chia
 
 count=1
 while :; do
-	processes=$(pgrep chia | grep -v grep | wc -l)
+	processes=$(pgrep chia_ | wc -l)
 	echo "found $processes running chia processes. Waiting for all processes to stop..."
 
 	# Exit conditions


### PR DESCRIPTION
Ensures that the script doesn't fail by waiting for the unrelated chia-exporter process to exit