### PR TITLE
Update monit to restart chia only after it has failed for a specified…

### DIFF
--- a/chia-blockchain/defaults/main.yml
+++ b/chia-blockchain/defaults/main.yml
@@ -189,3 +189,5 @@ vector_start_now: true
 # monit service related
 add_monit_config: true
 monit_start_now: true
+# How many times the port check needs to fail before monit will restart the service
+chia_monit_failure_threshold: 3

--- a/chia-blockchain/templates/monit_config.j2
+++ b/chia-blockchain/templates/monit_config.j2
@@ -1,5 +1,5 @@
 check host localhost with address 127.0.0.1
     start program = "/bin/systemctl start {{ chia_service_base }}.target" with timeout 600 seconds
     stop program = "/bin/systemctl stop {{ chia_service_base }}.target"
-    if failed port {{ full_node_port }} then restart
-    if 5 restarts within 5 cycles then timeout
+    if failed port {{ full_node_port }} for {{ chia_monit_failure_threshold }} cycles then restart
+    if 5 restarts within {{ 5 * chia_monit_failure_threshold }} cycles then timeout


### PR DESCRIPTION
… number of checks in a row

Avoids the case where monit happens to run right when other automation is already restart chia