### PR TITLE
Add config for chia-exporter port

### DIFF
--- a/chia-exporter/defaults/main.yml
+++ b/chia-exporter/defaults/main.yml
@@ -3,6 +3,7 @@ chia_exporter_version: latest
 chia_exporter_service_name: chia-exporter.service
 chia_exporter_start_on_boot: true
 chia_exporter_start_now: true
+chia_exporter_port: 9914
 
 download_maxmind_db: false
 maxmind_db_backup_bucket: ""

--- a/chia-exporter/templates/chia-exporter.service.j2
+++ b/chia-exporter/templates/chia-exporter.service.j2
@@ -4,6 +4,7 @@ Description=Chia Exporter Service for {{ user }}
 [Service]
 Type=simple
 Environment=CHIA_ROOT={{ chia_root }}
+Environment=CHIA_EXPORTER_METRICS_PORT={{ chia_exporter_port }}
 {% if download_maxmind_db == true %}
 Environment=CHIA_EXPORTER_MAXMIND_DB_PATH=/home/{{ user }}/bin/{{ maxmind_db_name }}
 {% endif %}


### PR DESCRIPTION
In some scenarios, some people (not naming names) might be running multiple farmers on a single machine, in which case, you'll want to be able to set the chia exporter port number.  OR maybe you already have something running on port 9914 - who knows.  