### PR TITLE
fix linter issues; add prometheus namespacing to prometheus vars

### DIFF
--- a/prometheus-node-exporter/defaults/main.yml
+++ b/prometheus-node-exporter/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-start_on_boot: yes
-start_now: yes
+prometheus_start_on_boot: true
+prometheus_start_now: true

--- a/prometheus-node-exporter/meta/main.yml
+++ b/prometheus-node-exporter/meta/main.yml
@@ -1,4 +1,1 @@
 ---
-dependencies:
-#  - role: geerlingguy.mac.homebrew
-#    when: ansible_os_family == "Darwin"

--- a/prometheus-node-exporter/tasks/darwin.yml
+++ b/prometheus-node-exporter/tasks/darwin.yml
@@ -1,15 +1,15 @@
 ---
 - name: Ensure that homebrew is installed
-  include_role:
+  ansible.builtin.include_role:
     name: geerlingguy.mac.homebrew
 
 - name: Install Prometheus Node Exporter
-  become: no
-  homebrew:
+  become: false
+  community.general.homebrew:
     name: node_exporter
     state: present
 
 - name: Ensure service is in desired boot and current state
-  become: no
-  shell: brew services start node_exporter
-  ignore_errors: yes
+  become: false
+  ansible.builtin.shell: brew services start node_exporter
+  ignore_errors: true

--- a/prometheus-node-exporter/tasks/debian.yml
+++ b/prometheus-node-exporter/tasks/debian.yml
@@ -1,20 +1,20 @@
 ---
 - name: Install Prometheus Node Exporter
-  become: yes
+  become: true
   ansible.builtin.apt:
     name:
       - prometheus-node-exporter
     state: present
-    update_cache: yes
+    update_cache: true
     cache_valid_time: 300
   register: apt_action
   retries: 100
   until: apt_action is success or ('Failed to lock apt for exclusive operation' not in apt_action.msg and '/var/lib/dpkg/lock' not in apt_action.msg)
 
 - name: Ensure service is in desired boot and current state
-  become: yes
+  become: true
   ansible.builtin.systemd:
     name: prometheus-node-exporter
-    daemon_reload: yes
-    enabled: "{{ start_on_boot }}"
-    state: "{{ start_now | ternary('started','stopped') }}"
+    daemon_reload: true
+    enabled: "{{ prometheus_start_on_boot }}"
+    state: "{{ prometheus_start_now | ternary('started', 'stopped') }}"

--- a/prometheus-node-exporter/tasks/main.yml
+++ b/prometheus-node-exporter/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-#This workflow is constructed to support multiple OSs
+# This workflow is constructed to support multiple OSs
 - name: Install from node-exporter on Debian-based OSs
   ansible.builtin.include_tasks: "debian.yml"
   when: ansible_os_family == "Debian"


### PR DESCRIPTION
Prometheus variables were the same for `start_now` and the enabling thing and they collided with the chia_blockchain variables, making it difficult to use both roles in the same playbook.  I've added the new prometheus_start_now variables to AMI builds, as this is the only place I'm aware that we change these beyond the default. 