### PR TITLE
Add multi-user port generation option

### DIFF
--- a/chia-blockchain/tasks/main.yml
+++ b/chia-blockchain/tasks/main.yml
@@ -8,6 +8,40 @@
       paths:
         - 'vars'
 
+- name: Load multi-user vars
+  when: chia_multi_user_number is defined
+  ansible.builtin.include_vars: "{{ lookup('first_found', params) }}"
+  vars:
+    params:
+      files:
+        - 'multi-user.yml'
+      paths:
+        - 'vars'
+
+- name:
+  when: chia_multi_user_number is defined
+  ansible.builtin.debug:
+    var: multi_user_vars
+  vars:
+    multi_user_vars:
+      chia_multi_user_number: "{{ chia_multi_user_number }}"
+      chia_daemon_port: "{{ chia_daemon_port }}"
+      chia_timelord_launcher_port: "{{ chia_timelord_launcher_port }}"
+      chia_ui_port: "{{ chia_ui_port }}"
+      full_node_port: "{{ full_node_port }}"
+      introducer_port: "{{ introducer_port }}"
+      chia_timelord_port: "{{ chia_timelord_port }}"
+      chia_farmer_port: "{{ chia_farmer_port }}"
+      chia_harvester_port: "{{ chia_harvester_port }}"
+      chia_wallet_port: "{{ chia_wallet_port }}"
+      chia_full_node_rpc_port: "{{ chia_full_node_rpc_port }}"
+      chia_farmer_rpc_port: "{{ chia_farmer_rpc_port }}"
+      chia_harvester_rpc_port: "{{ chia_harvester_rpc_port }}"
+      chia_wallet_rpc_port: "{{ chia_wallet_rpc_port }}"
+      chia_data_layer_port: "{{ chia_data_layer_port }}"
+      chia_data_layer_rpc_port: "{{ chia_data_layer_rpc_port }}"
+      chia_data_layer_host_port: "{{ chia_data_layer_host_port }}"
+
 - name: Cleanup any old leftovers
   ansible.builtin.include_tasks: "cleanup.yml"
 

--- a/chia-blockchain/vars/multi-user.yml
+++ b/chia-blockchain/vars/multi-user.yml
@@ -1,0 +1,27 @@
+---
+# The following defines ports for chia-blockchain when multiple instances are installed on the same host under
+# different user accounts. In scenarios such as this, it is tedious to generate and track unique ports for each install
+# Using these vars will just generate new ports sequentially starting at port 2000 for each user
+# chia-blockchain currently uses 16 unique ports, but we reserve 20 in these calculations for future port usage
+#
+# Defines the numbered user that will be created. We currently support between 1 and 100
+# chia_multi_user_number: 1
+chia_reserved_ports_per_user: 20
+
+chia_daemon_port: "{{ 2000 + (chia_reserved_ports_per_user * (chia_multi_user_number - 1)) + 0 }}"
+chia_timelord_launcher_port: "{{ 2000 + (chia_reserved_ports_per_user * (chia_multi_user_number - 1)) + 1 }}"
+chia_ui_port: "{{ 2000 + (chia_reserved_ports_per_user * (chia_multi_user_number - 1)) + 2 }}"
+full_node_port: "{{ 2000 + (chia_reserved_ports_per_user * (chia_multi_user_number - 1)) + 3 }}"
+introducer_port: "{{ 2000 + (chia_reserved_ports_per_user * (chia_multi_user_number - 1)) + 3 }}"
+chia_timelord_port: "{{ 2000 + (chia_reserved_ports_per_user * (chia_multi_user_number - 1)) + 4 }}"
+chia_farmer_port: "{{ 2000 + (chia_reserved_ports_per_user * (chia_multi_user_number - 1)) + 5 }}"
+chia_harvester_port: "{{ 2000 + (chia_reserved_ports_per_user * (chia_multi_user_number - 1)) + 6 }}"
+chia_wallet_port: "{{ 2000 + (chia_reserved_ports_per_user * (chia_multi_user_number - 1)) + 7 }}"
+chia_full_node_rpc_port: "{{ 2000 + (chia_reserved_ports_per_user * (chia_multi_user_number - 1)) + 8 }}"
+chia_farmer_rpc_port: "{{ 2000 + (chia_reserved_ports_per_user * (chia_multi_user_number - 1)) + 9 }}"
+chia_harvester_rpc_port: "{{ 2000 + (chia_reserved_ports_per_user * (chia_multi_user_number - 1)) + 10 }}"
+chia_wallet_rpc_port: "{{ 2000 + (chia_reserved_ports_per_user * (chia_multi_user_number - 1)) + 11 }}"
+chia_data_layer_port: "{{ 2000 + (chia_reserved_ports_per_user * (chia_multi_user_number - 1)) + 12 }}"
+# Crawler also uses the same port as data_layer by default, but its not currently a variable
+chia_data_layer_rpc_port: "{{ 2000 + (chia_reserved_ports_per_user * (chia_multi_user_number - 1)) + 13 }}"
+chia_data_layer_host_port: "{{ 2000 + (chia_reserved_ports_per_user * (chia_multi_user_number - 1)) + 14 }}"


### PR DESCRIPTION
When `chia_multi_user_number` is defined and set to some value between 1 and 100, you can automatically generate a set of incremental port numbers so that multiple users can run chia without port conflicts on the same machine.

For example, with `chia_multi_user_number: 1`
![Screenshot 2023-08-21 at 8 55 08 PM](https://github.com/Chia-Network/ansible-roles/assets/1915905/295c2111-9a2f-4fac-bdae-1b0b3bce3c41)



with `chia_multi_user_number: 2`
![Screenshot 2023-08-21 at 8 55 39 PM](https://github.com/Chia-Network/ansible-roles/assets/1915905/ea89e9cc-9f9f-41a9-a923-f0c366be50a4)
