### PR TITLE
always restart climate applications after install

### DIFF
--- a/cadt/tasks/main.yml
+++ b/cadt/tasks/main.yml
@@ -36,7 +36,7 @@
     name: "cadt@{{ user }}.service"
     daemon_reload: true
     enabled: true
-    state: started
+    state: restarted
   tags: cadt
 
 - name: Add CADT config file

--- a/climate-explorer/tasks/main.yml
+++ b/climate-explorer/tasks/main.yml
@@ -36,7 +36,7 @@
     name: "climate-explorer-chia@{{ user }}.service"
     daemon_reload: true
     enabled: true
-    state: started
+    state: restarted
   tags: climate-explorer
 
 - name: Wait for Climate Explorer config file to be present before continuing

--- a/core-registry-api/tasks/main.yml
+++ b/core-registry-api/tasks/main.yml
@@ -139,7 +139,7 @@
     name: "core-registry-api@{{ user }}.service"
     daemon_reload: true
     enabled: true
-    state: started
+    state: restarted
   tags: core-registry-api
 
 # TO BE ADDED IN NEAR FUTURE


### PR DESCRIPTION
When installing and configuring climate applications for multiple users on the same machine, only the user that triggers the software update will have the software restarted, the others will continue running the old version.  Change the state check to be "restarted" to always restart the service when Ansible runs to ensure all the latest changes are picked up. 