### PR TITLE
Remove port check from monit in favor of the specific healthcheck

### DIFF
--- a/chia-blockchain/templates/monit_config.j2
+++ b/chia-blockchain/templates/monit_config.j2
@@ -1,7 +1,6 @@
 check host localhost with address 127.0.0.1
     start program = "/bin/systemctl start {{ chia_service_base }}.target" with timeout 600 seconds
     stop program = "/bin/systemctl stop {{ chia_service_base }}.target"
-    if failed port {{ full_node_port }} for {{ chia_monit_failure_threshold }} cycles then restart
 {% if chia_add_healthcheck_service %}
     if failed port {{ chia_healthcheck_port }} protocol http request "/full_node" status = 200 for 1 cycles then restart
 {% endif %}


### PR DESCRIPTION
The port check doesn't seem to be reliably working with current versions of monit, and the healthcheck is better anyways, since it will report on synced status, not just an open port