### PR TITLE
Enable fail2ban service to start on boot by default

### DIFF
--- a/fail2ban/defaults/main.yml
+++ b/fail2ban/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
-start_on_boot: yes
+fail2ban_start_on_boot: yes
 
-ignoreip: 127.0.0.1/8 ::1
-bantime: 10m
-findtime: 10m
-maxretry: 5
+fail2ban_ignoreip: 127.0.0.1/8 ::1
+fail2ban_bantime: 10m
+fail2ban_findtime: 10m
+fail2ban_maxretry: 5

--- a/fail2ban/defaults/main.yml
+++ b/fail2ban/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
+start_on_boot: yes
+
 ignoreip: 127.0.0.1/8 ::1
 bantime: 10m
 findtime: 10m

--- a/fail2ban/tasks/main.yml
+++ b/fail2ban/tasks/main.yml
@@ -16,7 +16,7 @@
   ansible.builtin.systemd:
     name: fail2ban
     daemon_reload: true
-    enabled: "{{ start_on_boot }}"
+    enabled: "{{ fail2ban_start_on_boot }}"
 
 - name: Add jail.local config
   become: true

--- a/fail2ban/tasks/main.yml
+++ b/fail2ban/tasks/main.yml
@@ -11,6 +11,13 @@
   retries: 100
   until: apt_action is success or ('Failed to lock apt for exclusive operation' not in apt_action.msg and '/var/lib/dpkg/lock' not in apt_action.msg)
 
+- name: Ensure service is in desired boot state
+  become: true
+  ansible.builtin.systemd:
+    name: fail2ban
+    daemon_reload: true
+    enabled: "{{ start_on_boot }}"
+
 - name: Add jail.local config
   become: true
   ansible.builtin.template:

--- a/fail2ban/templates/jail.local.j2
+++ b/fail2ban/templates/jail.local.j2
@@ -2,14 +2,14 @@
 # "ignoreip" can be an IP address, a CIDR mask or a DNS host. Fail2ban will not
 # ban a host which matches an address in this list. Several addresses can be
 # defined using space separator.
-ignoreip = {{ ignoreip }}
+ignoreip = {{ fail2ban_ignoreip }}
 
 # "bantime" is the number of seconds that a host is banned.
-bantime = {{ bantime }}
+bantime = {{ fail2ban_bantime }}
 
 # A host is banned if it has generated "maxretry" during the last "findtime"
 # seconds.
-findtime = {{ findtime }}
+findtime = {{ fail2ban_findtime }}
 
 # "maxretry" is the number of failures before a host get banned.
-maxretry = {{ maxretry }}
+maxretry = {{ fail2ban_maxretry }}


### PR DESCRIPTION
Also adds a prefix for all fail2ban vars. Nothing currently setting any of these vars manually, so this change is pretty safe