### PR TITLE
Serve datalayer files directly with Nginx as an option vs proxying

### DIFF
--- a/datalayer-proxy/defaults/main.yml
+++ b/datalayer-proxy/defaults/main.yml
@@ -1,7 +1,14 @@
 ---
+# Two options to serve datalayer files
+#    proxy: nginx will proxy requests to the datalayer_http service
+#    direct: nginx will serve datalayer .dat files directly from disk
+datalayer_serving_type: proxy
+
 datalayer_public_host: data.example.com # URL that the public will use
-datalayer_public_path: "/data/" # Path of the datalayer proxy (include leading and trailing slash)
+datalayer_public_path: "data" # Path of the datalayer proxy (do not include leading and trailing slash)
 datalayer_host: "127.0.0.1" # Host where the datalayer files are served
 
 chia_data_layer_host_port: 8575 # Port for datalayer http server, set in chia-blockchain role
 datalayer_proxy_cache_expires: "365d" # Expires header in Nginx for CDN and Browser caching of datalayer files
+
+datalayer_direct_webroot: /var/www/{{ datalayer_public_host }}/{{ datalayer_public_path }}

--- a/datalayer-proxy/meta/main.yml
+++ b/datalayer-proxy/meta/main.yml
@@ -1,3 +1,4 @@
 ---
 dependencies:
   - role: nginx
+  - role: chia-blockchain

--- a/datalayer-proxy/tasks/main.yml
+++ b/datalayer-proxy/tasks/main.yml
@@ -10,21 +10,65 @@
   tags: datalayer-proxy
   notify: Reload-nginx
 
-- name: Create directory for Datalayer proxy includes
+- name: Create directory for Datalayer includes
   become: true
   ansible.builtin.file:
-    path: /etc/nginx/datalayer_proxy_includes
+    path: /etc/nginx/datalayer_includes
     state: directory
     mode: '0755'
     owner: "root"
     group: "root"
   tags: datalayer-proxy
 
-- name: Nginx include file for datalayer HTTP proxy
+- name: Create webroot for datalayer .dat files when direct serve
+  become: true
+  ansible.builtin.file:
+    path: "{{ datalayer_direct_webroot }}"
+    state: directory
+    mode: '0755'
+    owner: "{{ user }}"
+    group: "{{ group }}"
+  tags: datalayer-proxy
+  when: datalayer_serving_type == 'direct'
+
+- name: Check if the default Chia datalayer file path is a symlink
+  ansible.builtin.stat:
+    path: "{{ chia_root }}/data_layer/db/server_files_location_{{ network }}"
+  register: mylinks
+
+- name: If datalayer file path exists but is not a symlink, copy all files to the new directory
+  ansible.builtin.copy:
+    remote_src: true
+    src: "{{ chia_root }}/data_layer/db/server_files_location_{{ network }}/"
+    dest: "{{ datalayer_direct_webroot }}"
+    owner: "{{ user }}"
+    group: "{{ group }}"
+    mode: '0644'
+  tags: datalayer-proxy
+  when: datalayer_serving_type == 'direct' and mylinks.stat.exists and (mylinks.stat.islnk is not defined or mylinks.stat.islnk is false)
+
+- name: If datalayer file path exists but is not a symlink, delete directory
+  ansible.builtin.file:
+    path: "{{ chia_root }}/data_layer/db/server_files_location_{{ network }}/"
+    state: absent
+  tags: datalayer-proxy
+  when: datalayer_serving_type == 'direct' and mylinks.stat.exists and (mylinks.stat.islnk is not defined or mylinks.stat.islnk is false)
+
+- name: Create symlink to new datalayer file location
+  ansible.builtin.file:
+    src: "{{ datalayer_direct_webroot }}"
+    dest: "{{ chia_root }}/data_layer/db/server_files_location_{{ network }}"
+    state: link
+    owner: "{{ user }}"
+    group: "{{ group }}"
+  tags: datalayer-proxy
+  when: datalayer_serving_type == 'direct'
+
+- name: Nginx include file for datalayer HTTP proxy or direct file serve
   become: true
   ansible.builtin.template:
-    src: datalayer-proxy.inc.j2
-    dest: /etc/nginx/datalayer_proxy_includes/datalayer-proxy-{{ chia_data_layer_host_port }}.inc
+    src: datalayer-{{ datalayer_serving_type }}.inc.j2
+    dest: /etc/nginx/datalayer_includes/datalayer-{{ datalayer_public_host }}.{{ datalayer_public_path }}.inc
     owner: root
     group: root
     mode: '0644'

--- a/datalayer-proxy/templates/datalayer-direct.inc.j2
+++ b/datalayer-proxy/templates/datalayer-direct.inc.j2
@@ -1,0 +1,3 @@
+    location /{{ datalayer_public_path }}/ {
+        alias {{ datalayer_direct_webroot }}/;
+    }

--- a/datalayer-proxy/templates/datalayer-proxy.inc.j2
+++ b/datalayer-proxy/templates/datalayer-proxy.inc.j2
@@ -1,4 +1,4 @@
-    location {{ datalayer_public_path }} {
+    location /{{ datalayer_public_path }}/ {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_pass http://{{ datalayer_host }}:{{ chia_data_layer_host_port }}/;
     }

--- a/datalayer-proxy/templates/datalayer.conf.j2
+++ b/datalayer-proxy/templates/datalayer.conf.j2
@@ -31,7 +31,6 @@ server {
         try_files $uri $uri/ =404;
     }
 
-
-    include /etc/nginx/datalayer_proxy_includes/*.inc;
+    include /etc/nginx/datalayer_includes/*.inc;
 
 }


### PR DESCRIPTION
Add option to serve datalayer files directly with Nginx.  Original way of serving by proxying to datalayer http is still available.  Involves creating a new directory outside the home dir that Nginx would have access to and copying the files over from the original location. Decided to do a symlink from the original default location vs setting the location via the config.yaml file to make it the least amount of confusing..... I feel people will look for these files in the default location and by doing a symlink, everything is where you'd expect.