### PR TITLE
Adjust logging

### DIFF
--- a/chia-blockchain/defaults/main.yml
+++ b/chia-blockchain/defaults/main.yml
@@ -264,6 +264,8 @@ monit_start_now: true
 chia_alerts_receiver_token: ""
 chia_monit_alert_on_restart: false
 chia_monit_alert_webhook_url: ""
+# How many times the port check needs to fail before monit will increase chia logging to DEBUG
+chia_monit_log_debug_threshold: 2
 # How many times the port check needs to fail before monit will restart the service
 chia_monit_failure_threshold: 3
 

--- a/chia-blockchain/tasks/main.yml
+++ b/chia-blockchain/tasks/main.yml
@@ -264,6 +264,15 @@
   when: add_monit_config
   notify: restart-monit
 
+- name: Add a script to swap the log level prior to a restart
+  become: true
+  ansible.builtin.template:
+    src: monit_change_log_level.sh
+    dest: /etc/monit/monit-change-log-level.sh
+    mode: "0744"
+  when: add_monit_config
+  notify: restart-monit
+
 - name: Start or Restart the Monit Service
   become: true
   ansible.builtin.service:

--- a/chia-blockchain/templates/monit_change_log_level.sh
+++ b/chia-blockchain/templates/monit_change_log_level.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 set -o pipefail
 CHIA_PATH="/home/{{ user }}/chia-blockchain"
-# shellcheck disable=SC1091
+
 if [ -d "$CHIA_PATH" ]; then
-		echo "Found $CHIA_PATH — activating environment..."
-		. "$CHIA_PATH/activate"
+	echo "Found $CHIA_PATH — activating environment..."
+	. "$CHIA_PATH/activate"
 else
-		echo "$CHIA_PATH not found — Chia is installed with apt. Continuing...."
+	echo "$CHIA_PATH not found — Chia is installed with apt. Continuing...."
 fi
 
 # Set log level to DEBUG, wait, then revert to INFO

--- a/chia-blockchain/templates/monit_change_log_level.sh
+++ b/chia-blockchain/templates/monit_change_log_level.sh
@@ -4,6 +4,7 @@ CHIA_PATH="/home/{{ user }}/chia-blockchain"
 
 if [ -d "$CHIA_PATH" ]; then
 		echo "Found $CHIA_PATH — activating environment..."
+		# shellcheck source=/dev/null
 		. "$CHIA_PATH/activate"
 else
 		echo "$CHIA_PATH not found — Chia is installed with apt. Continuing...."

--- a/chia-blockchain/templates/monit_change_log_level.sh
+++ b/chia-blockchain/templates/monit_change_log_level.sh
@@ -3,10 +3,10 @@ set -o pipefail
 CHIA_PATH="/home/{{ user }}/chia-blockchain"
 
 if [ -d "$CHIA_PATH" ]; then
-    echo "Found $CHIA_PATH — activating environment..."
-    . "$CHIA_PATH/activate"
+		echo "Found $CHIA_PATH — activating environment..."
+		. "$CHIA_PATH/activate"
 else
-    echo "$CHIA_PATH not found — Chia is installed with apt. Continuing...."
+		echo "$CHIA_PATH not found — Chia is installed with apt. Continuing...."
 fi
 
 # Set log level to DEBUG, wait, then revert to INFO

--- a/chia-blockchain/templates/monit_change_log_level.sh
+++ b/chia-blockchain/templates/monit_change_log_level.sh
@@ -13,7 +13,7 @@ fi
 chia rpc full_node set_log_level '{ "level": "DEBUG" }'
 chia rpc timelord set_log_level '{ "level": "DEBUG" }'
 echo "Log level set to DEBUG. Sleeping for 1 minute...."
-sleep 1
+sleep 60
 chia rpc full_node set_log_level '{ "level": "INFO" }'
 chia rpc timelord set_log_level '{ "level": "INFO" }'
 echo "Log level set back to INFO"

--- a/chia-blockchain/templates/monit_change_log_level.sh
+++ b/chia-blockchain/templates/monit_change_log_level.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -o pipefail
+CHIA_PATH="/home/ubuntu/chia-blockchain"
+
+if [ -d "$CHIA_PATH" ]; then
+    echo "Found $CHIA_PATH — activating environment..."
+    . "$CHIA_PATH/activate"
+else
+    echo "$CHIA_PATH not found — Chia is installed with apt. Continuing...."
+fi
+
+# Set log level to DEBUG, wait, then revert to INFO
+chia configure --log-level DEBUG
+echo "Log level set to DEBUG. Restarting chia services...."
+sudo systemctl restart chia.target
+sleep 1
+chia configure --log-level INFO
+echo "Log level set to INFO. Restarting chia services...."
+sudo systemctl restart chia.target

--- a/chia-blockchain/templates/monit_change_log_level.sh
+++ b/chia-blockchain/templates/monit_change_log_level.sh
@@ -4,8 +4,9 @@ CHIA_PATH="/home/{{ user }}/chia-blockchain"
 
 if [ -d "$CHIA_PATH" ]; then
 		echo "Found $CHIA_PATH — activating environment..."
-		# shellcheck source=/dev/null
+		# shellcheck disable=SC1091
 		. "$CHIA_PATH/activate"
+		# shellcheck enable=SC1091
 else
 		echo "$CHIA_PATH not found — Chia is installed with apt. Continuing...."
 fi

--- a/chia-blockchain/templates/monit_change_log_level.sh
+++ b/chia-blockchain/templates/monit_change_log_level.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -o pipefail
-CHIA_PATH="/home/ubuntu/chia-blockchain"
+CHIA_PATH="/home/{{ user }}/chia-blockchain"
 
 if [ -d "$CHIA_PATH" ]; then
     echo "Found $CHIA_PATH — activating environment..."

--- a/chia-blockchain/templates/monit_change_log_level.sh
+++ b/chia-blockchain/templates/monit_change_log_level.sh
@@ -1,12 +1,10 @@
 #!/bin/bash
 set -o pipefail
 CHIA_PATH="/home/{{ user }}/chia-blockchain"
-
+# shellcheck disable=SC1091
 if [ -d "$CHIA_PATH" ]; then
 		echo "Found $CHIA_PATH — activating environment..."
-		# shellcheck disable=SC1091
 		. "$CHIA_PATH/activate"
-		# shellcheck enable=SC1091
 else
 		echo "$CHIA_PATH not found — Chia is installed with apt. Continuing...."
 fi

--- a/chia-blockchain/templates/monit_change_log_level.sh
+++ b/chia-blockchain/templates/monit_change_log_level.sh
@@ -10,10 +10,10 @@ else
 fi
 
 # Set log level to DEBUG, wait, then revert to INFO
-chia configure --log-level DEBUG
-echo "Log level set to DEBUG. Restarting chia services...."
-sudo systemctl restart chia.target
+chia rpc full_node set_log_level '{ "level": "DEBUG" }'
+chia rpc timelord set_log_level '{ "level": "DEBUG" }'
+echo "Log level set to DEBUG. Sleeping for 1 minute...."
 sleep 1
-chia configure --log-level INFO
-echo "Log level set to INFO. Restarting chia services...."
-sudo systemctl restart chia.target
+chia rpc full_node set_log_level '{ "level": "INFO" }'
+chia rpc timelord set_log_level '{ "level": "INFO" }'
+echo "Log level set back to INFO"

--- a/chia-blockchain/templates/monit_config.j2
+++ b/chia-blockchain/templates/monit_config.j2
@@ -3,7 +3,8 @@ check host localhost with address 127.0.0.1
     stop program = "/bin/systemctl stop {{ chia_service_base }}.target"
 {% if chia_add_healthcheck_service %}
     {% if "full-node" in chia_enabled_services %}
-    if failed port {{ chia_healthcheck_port }} protocol http request "/full_node" status = 200 for {{ chia_monit_failure_threshold }} cycles then restart
+if failed port {{ chia_healthcheck_port }} protocol http request "/full_node" status = 200 for {{ chia_monit_log_debug_threshold }} cycles then exec "/etc/monit/monit-change-log-level.sh"
+if failed port {{ chia_healthcheck_port }} protocol http request "/full_node" status = 200 for {{ chia_monit_failure_threshold }} cycles then restart
     {% endif %}
     {% if "timelord" in chia_enabled_services %}
     if failed port {{ chia_healthcheck_port }} protocol http request "/timelord" status = 200 for {{ chia_monit_log_debug_threshold }} cycles then exec "/etc/monit/monit-change-log-level.sh"

--- a/chia-blockchain/templates/monit_config.j2
+++ b/chia-blockchain/templates/monit_config.j2
@@ -3,8 +3,8 @@ check host localhost with address 127.0.0.1
     stop program = "/bin/systemctl stop {{ chia_service_base }}.target"
 {% if chia_add_healthcheck_service %}
     {% if "full-node" in chia_enabled_services %}
-if failed port {{ chia_healthcheck_port }} protocol http request "/full_node" status = 200 for {{ chia_monit_log_debug_threshold }} cycles then exec "/etc/monit/monit-change-log-level.sh"
-if failed port {{ chia_healthcheck_port }} protocol http request "/full_node" status = 200 for {{ chia_monit_failure_threshold }} cycles then restart
+    if failed port {{ chia_healthcheck_port }} protocol http request "/full_node" status = 200 for {{ chia_monit_log_debug_threshold }} cycles then exec "/etc/monit/monit-change-log-level.sh"
+    if failed port {{ chia_healthcheck_port }} protocol http request "/full_node" status = 200 for {{ chia_monit_failure_threshold }} cycles then restart
     {% endif %}
     {% if "timelord" in chia_enabled_services %}
     if failed port {{ chia_healthcheck_port }} protocol http request "/timelord" status = 200 for {{ chia_monit_log_debug_threshold }} cycles then exec "/etc/monit/monit-change-log-level.sh"

--- a/chia-blockchain/templates/monit_config.j2
+++ b/chia-blockchain/templates/monit_config.j2
@@ -3,11 +3,11 @@ check host localhost with address 127.0.0.1
     stop program = "/bin/systemctl stop {{ chia_service_base }}.target"
 {% if chia_add_healthcheck_service %}
     {% if "full-node" in chia_enabled_services %}
-    if failed port {{ chia_healthcheck_port }} protocol http request "/full_node" status = 200 for 2 cycles then restart
+    if failed port {{ chia_healthcheck_port }} protocol http request "/full_node" status = 200 for {{ chia_monit_failure_threshold }} cycles then restart
     {% endif %}
     {% if "timelord" in chia_enabled_services %}
-    if failed port {{ chia_healthcheck_port }} protocol http request "/timelord" status = 200 for 1 cycles then exec "/etc/monit/monit-change-log-level.sh"
-    if failed port {{ chia_healthcheck_port }} protocol http request "/timelord" status = 200 for 2 cycles then restart
+    if failed port {{ chia_healthcheck_port }} protocol http request "/timelord" status = 200 for {{ chia_monit_log_debug_threshold }} cycles then exec "/etc/monit/monit-change-log-level.sh"
+    if failed port {{ chia_healthcheck_port }} protocol http request "/timelord" status = 200 for {{ chia_monit_failure_threshold }} cycles then restart
     {% endif %}
     if 5 restarts within {{ 5 * chia_monit_failure_threshold }} cycles then timeout
     {% if chia_monit_alert_on_restart %}

--- a/chia-blockchain/templates/monit_config.j2
+++ b/chia-blockchain/templates/monit_config.j2
@@ -3,10 +3,11 @@ check host localhost with address 127.0.0.1
     stop program = "/bin/systemctl stop {{ chia_service_base }}.target"
 {% if chia_add_healthcheck_service %}
     {% if "full-node" in chia_enabled_services %}
-    if failed port {{ chia_healthcheck_port }} protocol http request "/full_node" status = 200 for 1 cycles then restart
+    if failed port {{ chia_healthcheck_port }} protocol http request "/full_node" status = 200 for 2 cycles then restart
     {% endif %}
     {% if "timelord" in chia_enabled_services %}
-    if failed port {{ chia_healthcheck_port }} protocol http request "/timelord" status = 200 for 1 cycles then restart
+    if failed port {{ chia_healthcheck_port }} protocol http request "/timelord" status = 200 for 1 cycles then exec "/etc/monit/monit-change-log-level.sh"
+    if failed port {{ chia_healthcheck_port }} protocol http request "/timelord" status = 200 for 2 cycles then restart
     {% endif %}
     if 5 restarts within {{ 5 * chia_monit_failure_threshold }} cycles then timeout
     {% if chia_monit_alert_on_restart %}

--- a/chia-blockchain/templates/monit_hw_vdf.j2
+++ b/chia-blockchain/templates/monit_hw_vdf.j2
@@ -3,9 +3,10 @@ check file chia-hw-vdf-service with path /etc/systemd/system/chia-hw-vdf.service
 check program chia-hw-vdf with path "/bin/systemctl is-active --quiet chia-hw-vdf.service"
     start program = "/bin/systemctl start chia-hw-vdf.service"
     stop program = "/bin/systemctl stop chia-hw-vdf.service"
-    if status != 0 then restart
+    if status != 0 for 1 cycles then exec "/etc/monit/monit-change-log-level.sh"
+    if status != 0 for 2 cycles then restart
     depends on chia-hw-vdf-service
     # Prevent endless restart loops
     if 5 restarts within {{ 5 * chia_monit_failure_threshold }} cycles then timeout
     # notify keybase on restarts
-    if 1 restarts within {{ chia_monit_failure_threshold }} cycles then exec "/etc/monit/monit-notify-hw-vdf.sh"
+    if 2 restarts within {{ chia_monit_failure_threshold }} cycles then exec "/etc/monit/monit-notify-hw-vdf.sh"

--- a/chia-blockchain/templates/monit_hw_vdf.j2
+++ b/chia-blockchain/templates/monit_hw_vdf.j2
@@ -3,10 +3,9 @@ check file chia-hw-vdf-service with path /etc/systemd/system/chia-hw-vdf.service
 check program chia-hw-vdf with path "/bin/systemctl is-active --quiet chia-hw-vdf.service"
     start program = "/bin/systemctl start chia-hw-vdf.service"
     stop program = "/bin/systemctl stop chia-hw-vdf.service"
-    if status != 0 for 1 cycles then exec "/etc/monit/monit-change-log-level.sh"
-    if status != 0 for 2 cycles then restart
+    if status != 0 then restart
     depends on chia-hw-vdf-service
     # Prevent endless restart loops
     if 5 restarts within {{ 5 * chia_monit_failure_threshold }} cycles then timeout
     # notify keybase on restarts
-    if 2 restarts within {{ chia_monit_failure_threshold }} cycles then exec "/etc/monit/monit-notify-hw-vdf.sh"
+    if 1 restarts within 1 cycles then exec "/etc/monit/monit-notify-hw-vdf.sh"

--- a/linux-runner/templates/post-run.sh
+++ b/linux-runner/templates/post-run.sh
@@ -54,8 +54,8 @@ sudo rm -rf "/home/{{ runner_user }}/actions-runner/_work" || true
 
 # Reset the docker auth if we have a template
 if [ -f "${directory}/.docker/config.json.tmpl" ]; then
-  rm "${directory}/.docker/config.json" || true
-  cp "${directory}/.docker/config.json.tmpl" "${directory}/.docker/config.json"
+	rm "${directory}/.docker/config.json" || true
+	cp "${directory}/.docker/config.json.tmpl" "${directory}/.docker/config.json"
 fi
 
 # Check if any delete operations failed, and exit with code 1 if so

--- a/linux-runner/templates/pre-run.sh
+++ b/linux-runner/templates/pre-run.sh
@@ -44,8 +44,8 @@ done
 
 # Reset the docker auth if we have a template
 if [ -f "${directory}/.docker/config.json.tmpl" ]; then
-  rm "${directory}/.docker/config.json" || true
-  cp "${directory}/.docker/config.json.tmpl" "${directory}/.docker/config.json"
+	rm "${directory}/.docker/config.json" || true
+	cp "${directory}/.docker/config.json.tmpl" "${directory}/.docker/config.json"
 fi
 
 # Check if any delete operations failed, and exit with code 1 if so

--- a/monit/defaults/main.yml
+++ b/monit/defaults/main.yml
@@ -4,3 +4,4 @@ monit_start_now: yes
 
 #This is the delay time for monit to start checking after a system start
 monit_start_delay_secs: 3600
+monit_cycle_time: 60

--- a/monit/templates/chia_monitrc.j2
+++ b/monit/templates/chia_monitrc.j2
@@ -16,7 +16,7 @@
 ##
 ## Start Monit in the background (run as a daemon):
 #
-set daemon 60            # check services at 2-minute intervals
+set daemon 60            # check services at 1-minute intervals
     with start delay {{ monit_start_delay_secs }}    # optional: delay the first check by x-minutes (by
 #                           # default Monit check immediately after Monit start)
 #

--- a/monit/templates/chia_monitrc.j2
+++ b/monit/templates/chia_monitrc.j2
@@ -16,7 +16,7 @@
 ##
 ## Start Monit in the background (run as a daemon):
 #
-set daemon 120            # check services at 2-minute intervals
+set daemon 60            # check services at 2-minute intervals
     with start delay {{ monit_start_delay_secs }}    # optional: delay the first check by x-minutes (by
 #                           # default Monit check immediately after Monit start)
 #

--- a/monit/templates/chia_monitrc.j2
+++ b/monit/templates/chia_monitrc.j2
@@ -16,7 +16,7 @@
 ##
 ## Start Monit in the background (run as a daemon):
 #
-set daemon 60            # check services at 1-minute intervals
+set daemon {{ monit_cycle_time }}            # check services at specified intervals
     with start delay {{ monit_start_delay_secs }}    # optional: delay the first check by x-minutes (by
 #                           # default Monit check immediately after Monit start)
 #


### PR DESCRIPTION
Add a step to change the logging prior to a restart happening, when chia services go down - either for the full node or timelord