### PR TITLE
Only need to build chiavdf for timelord if running timelord launcher

### DIFF
--- a/chia-blockchain/tasks/source.yml
+++ b/chia-blockchain/tasks/source.yml
@@ -102,7 +102,8 @@
     CHIA_ROOT: "{{ chia_root }}"
   when: # List is AND
     - git_output.changed
-    - '"timelord" in chia_enabled_services or "timelord-launcher" in chia_enabled_services'
+    - '"timelord-launcher" in chia_enabled_services'
+    -
 
 # Since chia might have already been updated (via apt) from another user on this machine in some setups
 # We track the version as of the last time this role ran, and if it changes, we restart chia


### PR DESCRIPTION
timelord process is used by both the sw and asic implementation, and don't need the SW implementation built for asics