### PR TITLE
Install the apt key when installing chiahw-vdf

### DIFF
--- a/chia-blockchain/meta/main.yml
+++ b/chia-blockchain/meta/main.yml
@@ -7,7 +7,7 @@ dependencies:
   - role: monit
     when: add_monit_config or chia_add_hw_vdf_monit_config
   - role: chia-apt-key
-    when: chia_installation_method == "apt"
+    when: `chia_installation_method == "apt" or chia_enable_hw_vdf`
   - role: git
     when: chia_installation_method == "source"
   - role: chia-healthcheck

--- a/chia-blockchain/meta/main.yml
+++ b/chia-blockchain/meta/main.yml
@@ -7,7 +7,7 @@ dependencies:
   - role: monit
     when: add_monit_config or chia_add_hw_vdf_monit_config
   - role: chia-apt-key
-    when: `chia_installation_method == "apt" or chia_enable_hw_vdf`
+    when: 'chia_installation_method == "apt" or chia_enable_hw_vdf'
   - role: git
     when: chia_installation_method == "source"
   - role: chia-healthcheck


### PR DESCRIPTION
Lost this functionality when fixing the accidental chia install on the vdf only nodes that didn't need it - this resolves that