### PR TITLE
Add CADT v2 config format for version >= 1.7.26

### DIFF
--- a/cadt/defaults/main.yml
+++ b/cadt/defaults/main.yml
@@ -57,6 +57,42 @@ datalayer_http_location: "http://{{ climate_apps_domains | first }}:8575"
 # Chia network
 cadt_network: "mainnet"
 
+# New config format (>= 1.7.26)
+cadt_certificate_folder_path: null
+cadt_validate_organization_table_task_interval: 1800
+
+cadt_request_content_limits:
+  STAGING:
+    EDIT_DATA_LEN: 200
+  UNITS:
+    INCLUDE_COLUMNS_LEN: 200
+    MARKETPLACE_IDENTIFIERS_LEN: 200
+  PROJECTS:
+    INCLUDE_COLUMNS_LEN: 200
+    PROJECT_IDS_LEN: 200
+
+# V1 configuration - defaults inherit from the single-value variables above
+cadt_v1_enable: true
+cadt_v1_read_only: "{{ cadt_read_only }}"
+cadt_v1_api_key: "{{ cadt_api_key }}"
+cadt_v1_is_governance_body: "{{ cadt_is_governance_body }}"
+cadt_v1_governance_body_id: "{{ cadt_governance_body_id }}"
+cadt_v1_db_username: "{{ cadt_db_username }}"
+cadt_v1_db_password: "{{ cadt_db_password }}"
+cadt_v1_db_name: "{{ cadt_db_name }}"
+cadt_v1_db_host: "{{ cadt_db_host }}"
+
+# V2 configuration - disabled by default
+cadt_v2_enable: false
+cadt_v2_read_only: "{{ cadt_read_only }}"
+cadt_v2_api_key: "{{ cadt_api_key }}"
+cadt_v2_is_governance_body: "{{ cadt_is_governance_body }}"
+cadt_v2_governance_body_id: "{{ cadt_governance_body_id }}"
+cadt_v2_db_username: "{{ cadt_db_username }}"
+cadt_v2_db_password: "{{ cadt_db_password }}"
+cadt_v2_db_name: "{{ cadt_db_name }}"
+cadt_v2_db_host: "{{ cadt_db_host }}"
+
 # Backups
 backup_base_dir: /home/{{ user }}/backup
 backup_dir: "{{ backup_base_dir }}/{{ cadt_port }}"

--- a/cadt/defaults/main.yml
+++ b/cadt/defaults/main.yml
@@ -82,16 +82,16 @@ cadt_v1_db_password: "{{ cadt_db_password }}"
 cadt_v1_db_name: "{{ cadt_db_name }}"
 cadt_v1_db_host: "{{ cadt_db_host }}"
 
-# V2 configuration - disabled by default
+# V2 configuration - disabled by default, must be explicitly configured
 cadt_v2_enable: false
-cadt_v2_read_only: "{{ cadt_read_only }}"
-cadt_v2_api_key: "{{ cadt_api_key }}"
-cadt_v2_is_governance_body: "{{ cadt_is_governance_body }}"
-cadt_v2_governance_body_id: "{{ cadt_governance_body_id }}"
-cadt_v2_db_username: "{{ cadt_db_username }}"
-cadt_v2_db_password: "{{ cadt_db_password }}"
-cadt_v2_db_name: "{{ cadt_db_name }}"
-cadt_v2_db_host: "{{ cadt_db_host }}"
+cadt_v2_read_only: false
+cadt_v2_api_key: null
+cadt_v2_is_governance_body: false
+cadt_v2_governance_body_id: null
+cadt_v2_db_username: null
+cadt_v2_db_password: null
+cadt_v2_db_name: null
+cadt_v2_db_host: null
 
 # Backups
 backup_base_dir: /home/{{ user }}/backup

--- a/cadt/tasks/main.yml
+++ b/cadt/tasks/main.yml
@@ -39,9 +39,16 @@
     state: restarted
   tags: cadt
 
+- name: Determine CADT config format
+  ansible.builtin.set_fact:
+    cadt_use_v2_config: >-
+      {{ cadt_api_version != 'latest' and
+         (cadt_api_version | regex_replace('[-~]rc\d+$', '') is version('1.7.26', '>=')) }}
+  tags: cadt
+
 - name: Add CADT config file
   ansible.builtin.template:
-    src: "config.yaml.j2"
+    src: "{{ (cadt_use_v2_config | bool) | ternary('config-v2.yaml.j2', 'config.yaml.j2') }}"
     dest: "{{ chia_root }}/cadt/v1/config.yaml"
     owner: "{{ user }}"
     group: "{{ user }}"

--- a/cadt/tasks/main.yml
+++ b/cadt/tasks/main.yml
@@ -49,7 +49,7 @@
 - name: Add CADT config file
   ansible.builtin.template:
     src: "{{ (cadt_use_v2_config | bool) | ternary('config-v2.yaml.j2', 'config.yaml.j2') }}"
-    dest: "{{ chia_root }}/cadt/v1/config.yaml"
+    dest: "{{ chia_root }}/cadt/{{ (cadt_use_v2_config | bool) | ternary('', 'v1/') }}config.yaml"
     owner: "{{ user }}"
     group: "{{ user }}"
     mode: '0644'

--- a/cadt/tasks/main.yml
+++ b/cadt/tasks/main.yml
@@ -43,7 +43,7 @@
   ansible.builtin.set_fact:
     cadt_use_v2_config: >-
       {{ cadt_api_version != 'latest' and
-         (cadt_api_version | regex_replace('[-~]rc\d+$', '') is version('1.7.26', '>=')) }}
+      (cadt_api_version | regex_replace('[-~]rc\d+$', '') is version('1.7.26', '>=')) }}
   tags: cadt
 
 - name: Add CADT config file

--- a/cadt/templates/config-v2.yaml.j2
+++ b/cadt/templates/config-v2.yaml.j2
@@ -1,0 +1,54 @@
+APP:
+  CW_PORT: {{ cadt_port }}
+  BIND_ADDRESS: {{ cadt_bind_address }}
+  DATALAYER_URL: https://localhost:{{ chia_data_layer_rpc_port }}
+  WALLET_URL: https://localhost:{{ chia_wallet_rpc_port }}
+  USE_SIMULATOR: false
+  CHIA_NETWORK: {{ cadt_network }}
+  USE_DEVELOPMENT_MODE: false
+  DEFAULT_FEE: {{ cadt_default_fee }}
+  DEFAULT_COIN_AMOUNT: {{ cadt_default_coin_amount }}
+  CERTIFICATE_FOLDER_PATH: {{ cadt_certificate_folder_path }}
+  DATALAYER_FILE_SERVER_URL: {{ datalayer_http_location }}
+  AUTO_SUBSCRIBE_FILESTORE: {{ cadt_auto_subscribe_filestore }}
+  AUTO_MIRROR_EXTERNAL_STORES: {{ cadt_auto_mirror_external_stores }}
+  LOG_LEVEL: {{ cadt_log_level }}
+  TASKS:
+    GOVERNANCE_SYNC_TASK_INTERVAL: {{ cadt_governance_sync_task_interval }}
+    ORGANIZATION_META_SYNC_TASK_INTERVAL: {{ cadt_organization_meta_sync_task_interval }}
+    PICKLIST_SYNC_TASK_INTERVAL: {{ cadt_picklist_sync_task_interval }}
+    MIRROR_CHECK_TASK_INTERVAL: {{ cadt_mirror_check_task_interval }}
+    VALIDATE_ORGANIZATION_TABLE_TASK_INTERVAL: {{ cadt_validate_organization_table_task_interval }}
+  REQUEST_CONTENT_LIMITS:
+    STAGING:
+      EDIT_DATA_LEN: {{ cadt_request_content_limits.STAGING.EDIT_DATA_LEN }}
+    UNITS:
+      INCLUDE_COLUMNS_LEN: {{ cadt_request_content_limits.UNITS.INCLUDE_COLUMNS_LEN }}
+      MARKETPLACE_IDENTIFIERS_LEN: {{ cadt_request_content_limits.UNITS.MARKETPLACE_IDENTIFIERS_LEN }}
+    PROJECTS:
+      INCLUDE_COLUMNS_LEN: {{ cadt_request_content_limits.PROJECTS.INCLUDE_COLUMNS_LEN }}
+      PROJECT_IDS_LEN: {{ cadt_request_content_limits.PROJECTS.PROJECT_IDS_LEN }}
+V1:
+  ENABLE: {{ cadt_v1_enable }}
+  READ_ONLY: {{ cadt_v1_read_only }}
+  CADT_API_KEY: {{ cadt_v1_api_key }}
+  IS_GOVERNANCE_BODY: {{ cadt_v1_is_governance_body }}
+  GOVERNANCE:
+    GOVERNANCE_BODY_ID: {{ cadt_v1_governance_body_id }}
+  MIRROR_DB:
+    DB_USERNAME: {{ cadt_v1_db_username }}
+    DB_PASSWORD: {{ cadt_v1_db_password }}
+    DB_NAME: {{ cadt_v1_db_name }}
+    DB_HOST: {{ cadt_v1_db_host }}
+V2:
+  ENABLE: {{ cadt_v2_enable }}
+  READ_ONLY: {{ cadt_v2_read_only }}
+  CADT_API_KEY: {{ cadt_v2_api_key }}
+  IS_GOVERNANCE_BODY: {{ cadt_v2_is_governance_body }}
+  GOVERNANCE:
+    GOVERNANCE_BODY_ID: {{ cadt_v2_governance_body_id }}
+  MIRROR_DB:
+    DB_USERNAME: {{ cadt_v2_db_username }}
+    DB_PASSWORD: {{ cadt_v2_db_password }}
+    DB_NAME: {{ cadt_v2_db_name }}
+    DB_HOST: {{ cadt_v2_db_host }}


### PR DESCRIPTION
CADT 1.7.26 introduces a new config structure with separate V1/V2 sections, each with their own governance, DB, and API key settings. The role now detects the version and selects the appropriate config template, with V1/V2 defaults inheriting from existing variables for backward compatibility.