### PR TITLE
Add roles to install Alloy and uninstall Promtail

### DIFF
--- a/alloy/defaults/main.yml
+++ b/alloy/defaults/main.yml
@@ -1,0 +1,23 @@
+---
+# River configuration for Alloy (override in group_vars / host_vars)
+alloy_config: |
+  logging {
+    level  = "info"
+    format = "logfmt"
+  }
+
+# Optional extra snippets on disk; reference them from alloy_config with import.file "/etc/alloy/..."
+alloy_additional_files: []
+# Example:
+# alloy_additional_files:
+#   - path: /etc/alloy/extra.alloy
+#     content: |
+#       // ...
+
+# Supplementary groups so the alloy user can read logs (add host-specific groups as needed)
+alloy_user_groups:
+  - adm
+  - systemd-journal
+
+alloy_start_on_boot: true
+alloy_start_now: true

--- a/alloy/defaults/main.yml
+++ b/alloy/defaults/main.yml
@@ -18,6 +18,7 @@ alloy_additional_files: []
 alloy_user_groups:
   - adm
   - systemd-journal
+  - ubuntu
 
 alloy_start_on_boot: true
 alloy_start_now: true

--- a/alloy/defaults/main.yml
+++ b/alloy/defaults/main.yml
@@ -1,24 +1,49 @@
 ---
-# River configuration for Alloy (override in group_vars / host_vars)
-alloy_config: |
-  logging {
-    level  = "info"
-    format = "logfmt"
-  }
-
-# Optional extra snippets on disk; reference them from alloy_config with import.file "/etc/alloy/..."
-alloy_additional_files: []
-# Example:
-# alloy_additional_files:
-#   - path: /etc/alloy/extra.alloy
-#     content: |
-#       // ...
+alloy_log_level: "info"
+alloy_log_format: "logfmt"
 
 # Supplementary groups so the alloy user can read logs (add host-specific groups as needed)
 alloy_user_groups:
   - adm
   - systemd-journal
   - ubuntu
+
+# Loki push endpoint and auth
+loki_endpoint: ""
+loki_basic_auth_username: ""
+loki_basic_auth_password: ""
+
+# Chia log labels
+application: "chia-blockchain"
+component: "node"
+network: "mainnet"
+group_tag: "default"
+repo_ref: ""
+chia_root: "/home/ubuntu/.chia"
+
+# Extra log files to ship to the default Loki sink.
+# Each entry produces its own loki.source.file component.
+#
+# alloy_extra_log_files:
+#   - name: myapp
+#     path: /var/log/myapp.log
+#     job: myapp                   # optional, defaults to name
+#     extra_labels:                # optional
+#       environment: production
+alloy_extra_log_files: []
+
+# Arbitrary River config appended to the end of config.alloy.
+# Use for components not covered by the built-in scrape targets.
+alloy_extra_config: ""
+
+# Optional extra snippet files deployed to /etc/alloy/.
+# Reference them from alloy_extra_config with import.file "/etc/alloy/..."
+alloy_additional_files: []
+# Example:
+# alloy_additional_files:
+#   - path: /etc/alloy/extra.alloy
+#     content: |
+#       // ...
 
 alloy_start_on_boot: true
 alloy_start_now: true

--- a/alloy/handlers/main.yml
+++ b/alloy/handlers/main.yml
@@ -5,3 +5,7 @@
     name: alloy
     state: restarted
     daemon_reload: true
+  when: alloy_start_now
+  register: systemd_action
+  retries: 10
+  until: systemd_action is success

--- a/alloy/handlers/main.yml
+++ b/alloy/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+- name: restart alloy
+  become: true
+  ansible.builtin.systemd:
+    name: alloy
+    state: restarted
+    daemon_reload: true

--- a/alloy/tasks/main.yml
+++ b/alloy/tasks/main.yml
@@ -1,0 +1,97 @@
+---
+- name: Install deps
+  become: true
+  ansible.builtin.apt:
+    name:
+      - apt-transport-https
+      - curl
+      - gnupg
+      - python3-apt
+    state: present
+    update_cache: true
+    cache_valid_time: 300
+  register: apt_action
+  retries: 100
+  until: apt_action is success or ('Failed to lock apt for exclusive operation' not in apt_action.msg | default('') and '/var/lib/dpkg/lock' not in apt_action.msg | default(''))
+
+- name: Ensure apt keyrings directory exists
+  become: true
+  ansible.builtin.file:
+    path: /usr/share/keyrings
+    state: directory
+    mode: '0755'
+
+- name: Download Grafana GPG key
+  become: true
+  ansible.builtin.apt_key:
+    url: https://apt.grafana.com/gpg.key
+    state: present
+    keyring: /usr/share/keyrings/grafana.gpg
+
+- name: Add Grafana apt repository
+  become: true
+  ansible.builtin.apt_repository:
+    repo: "deb [signed-by=/usr/share/keyrings/grafana.gpg] https://apt.grafana.com stable main"
+    filename: grafana
+
+- name: Install Grafana Alloy
+  become: true
+  ansible.builtin.apt:
+    name: alloy
+    state: present
+  notify: restart alloy
+  register: apt_action
+  retries: 100
+  until: apt_action is success or ('Failed to lock apt for exclusive operation' not in apt_action.msg | default('') and '/var/lib/dpkg/lock' not in apt_action.msg | default(''))
+
+- name: Ensure Alloy config directory exists
+  become: true
+  ansible.builtin.file:
+    path: /etc/alloy
+    state: directory
+    mode: '0755'
+
+- name: Add alloy user to groups for log file access
+  become: true
+  ansible.builtin.user:
+    name: alloy
+    groups: "{{ alloy_user_groups | join(',') }}"
+    append: true
+  when: alloy_user_groups | length > 0
+
+- name: Deploy optional Alloy snippet files
+  become: true
+  ansible.builtin.copy:
+    dest: "{{ item.path }}"
+    content: "{{ item.content }}"
+    owner: root
+    group: alloy
+    mode: '0640'
+  loop: "{{ alloy_additional_files }}"
+  loop_control:
+    label: "{{ item.path }}"
+  notify: restart alloy
+
+- name: Template Alloy main config
+  become: true
+  ansible.builtin.template:
+    src: config.alloy.j2
+    dest: /etc/alloy/config.alloy
+    owner: root
+    group: alloy
+    mode: '0640'
+  notify: restart alloy
+
+- name: Set Alloy desired boot state
+  become: true
+  ansible.builtin.systemd:
+    name: alloy
+    daemon_reload: true
+    enabled: "{{ alloy_start_on_boot }}"
+
+- name: Set Alloy desired current state
+  become: true
+  ansible.builtin.systemd:
+    name: alloy
+    state: "{{ alloy_start_now | ternary('started', 'stopped') }}"
+  ignore_errors: true

--- a/alloy/templates/config.alloy.j2
+++ b/alloy/templates/config.alloy.j2
@@ -1,0 +1,1 @@
+{{ alloy_config }}

--- a/alloy/templates/config.alloy.j2
+++ b/alloy/templates/config.alloy.j2
@@ -1,1 +1,105 @@
-{{ alloy_config }}
+// Managed by Ansible – manual edits will be overwritten.
+
+logging {
+  level  = "{{ alloy_log_level }}"
+  format = "{{ alloy_log_format }}"
+}
+
+// ── Loki sink ────────────────────────────────────────────────────────────────
+
+loki.write "default" {
+  endpoint {
+    url = "{{ loki_endpoint }}"
+{% if loki_basic_auth_username and loki_basic_auth_password %}
+    basic_auth {
+      username = "{{ loki_basic_auth_username }}"
+      password = "{{ loki_basic_auth_password }}"
+    }
+{% endif %}
+  }
+}
+
+// ── Syslog ───────────────────────────────────────────────────────────────────
+
+loki.source.file "syslog" {
+  targets = [
+    {
+      __path__ = "/var/log/syslog",
+      job      = "syslog",
+      host     = "{{ ansible_hostname | default('localhost') }}",
+    },
+  ]
+  forward_to = [loki.write.default.receiver]
+}
+
+// ── Fail2ban ─────────────────────────────────────────────────────────────────
+
+loki.source.file "fail2ban" {
+  targets = [
+    {
+      __path__ = "/var/log/fail2ban.log",
+      job      = "fail2ban",
+      host     = "{{ ansible_hostname | default('localhost') }}",
+    },
+  ]
+  forward_to = [loki.write.default.receiver]
+}
+
+// ── Chia ─────────────────────────────────────────────────────────────────────
+
+loki.source.file "chia" {
+  targets = [
+    {
+      __path__    = "{{ chia_root }}/log/debug.log",
+      job         = "chia",
+      application = "{{ application }}",
+      component   = "{{ component }}",
+      network     = "{{ network }}",
+      group       = "{{ group_tag }}",
+      ref         = "{{ repo_ref }}",
+      host        = "{{ ansible_hostname | default('localhost') }}",
+    },
+  ]
+  forward_to = [loki.process.chia.receiver]
+}
+
+loki.process "chia" {
+  stage.multiline {
+    firstline     = "^(?P<year>[0-9]{4})-(?P<month>[0-9]{2})-(?P<day>[0-9]{2})T|^VDF\\.Client:"
+    max_wait_time = "15s"
+  }
+
+  stage.json {
+    expressions = {
+      year  = "year",
+      month = "month",
+      day   = "day",
+    }
+  }
+
+  forward_to = [loki.write.default.receiver]
+}
+
+// ── Extra log files ──────────────────────────────────────────────────────────
+{% for extra in alloy_extra_log_files %}
+
+loki.source.file "{{ extra.name }}" {
+  targets = [
+    {
+      __path__ = "{{ extra.path }}",
+      job      = "{{ extra.job | default(extra.name) }}",
+      host     = "{{ ansible_hostname | default('localhost') }}",
+{% for key, value in (extra.extra_labels | default({})).items() %}
+      {{ key }} = "{{ value }}",
+{% endfor %}
+    },
+  ]
+  forward_to = [loki.write.default.receiver]
+}
+{% endfor %}
+{% if alloy_extra_config %}
+
+// ── Extra config ─────────────────────────────────────────────────────────────
+
+{{ alloy_extra_config }}
+{% endif %}

--- a/promtail_uninstall/defaults/main.yml
+++ b/promtail_uninstall/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-  # Remove promtail log directory (often empty or promtail-owned); set false to leave in place
-  promtail_remove_log_dir: true
+# Remove promtail log directory (often empty or promtail-owned); set false to leave in place
+promtail_remove_log_dir: true

--- a/promtail_uninstall/defaults/main.yml
+++ b/promtail_uninstall/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+  # Remove promtail log directory (often empty or promtail-owned); set false to leave in place
+  promtail_remove_log_dir: true

--- a/promtail_uninstall/tasks/main.yml
+++ b/promtail_uninstall/tasks/main.yml
@@ -1,52 +1,51 @@
 ---
-  - name: Stop promtail service if present
-    become: true
-    ansible.builtin.systemd:
-      name: promtail
-      state: stopped
-    register: promtail_stop
-    failed_when: false
-    changed_when: promtail_stop is changed
-  
-  - name: Disable promtail service if present
-    become: true
-    ansible.builtin.systemd:
-      name: promtail
-      enabled: false
-    register: promtail_disable
-    failed_when: false
-    changed_when: promtail_disable is changed
-  
-  - name: Remove promtail package
-    become: true
-    ansible.builtin.apt:
-      name: promtail
-      state: absent
-      purge: true
-    register: apt_action
-    retries: 100
-    until: apt_action is success or ('Failed to lock apt for exclusive operation' not in apt_action.msg | default('') and '/var/lib/dpkg/lock' not in apt_action.msg | default(''))
-  
-  - name: Remove promtail configuration directory
-    become: true
-    ansible.builtin.file:
-      path: /etc/promtail
-      state: absent
-  
-  - name: Remove promtail log directory
-    become: true
-    ansible.builtin.file:
-      path: /var/log/promtail
-      state: absent
-    when: promtail_remove_log_dir | bool
-  
-  - name: Remove promtail system user
-    become: true
-    ansible.builtin.user:
-      name: promtail
-      state: absent
-      remove: true
-    register: promtail_user_remove
-    failed_when: false
-    changed_when: promtail_user_remove is changed
-  
+- name: Stop promtail service if present
+  become: true
+  ansible.builtin.systemd:
+    name: promtail
+    state: stopped
+  register: promtail_stop
+  failed_when: false
+  changed_when: promtail_stop is changed
+
+- name: Disable promtail service if present
+  become: true
+  ansible.builtin.systemd:
+    name: promtail
+    enabled: false
+  register: promtail_disable
+  failed_when: false
+  changed_when: promtail_disable is changed
+
+- name: Remove promtail package
+  become: true
+  ansible.builtin.apt:
+    name: promtail
+    state: absent
+    purge: true
+  register: apt_action
+  retries: 100
+  until: apt_action is success or ('Failed to lock apt for exclusive operation' not in apt_action.msg | default('') and '/var/lib/dpkg/lock' not in apt_action.msg | default(''))
+
+- name: Remove promtail configuration directory
+  become: true
+  ansible.builtin.file:
+    path: /etc/promtail
+    state: absent
+
+- name: Remove promtail log directory
+  become: true
+  ansible.builtin.file:
+    path: /var/log/promtail
+    state: absent
+  when: promtail_remove_log_dir | bool
+
+- name: Remove promtail system user
+  become: true
+  ansible.builtin.user:
+    name: promtail
+    state: absent
+    remove: true
+  register: promtail_user_remove
+  failed_when: false
+  changed_when: promtail_user_remove is changed

--- a/promtail_uninstall/tasks/main.yml
+++ b/promtail_uninstall/tasks/main.yml
@@ -1,0 +1,52 @@
+---
+  - name: Stop promtail service if present
+    become: true
+    ansible.builtin.systemd:
+      name: promtail
+      state: stopped
+    register: promtail_stop
+    failed_when: false
+    changed_when: promtail_stop is changed
+  
+  - name: Disable promtail service if present
+    become: true
+    ansible.builtin.systemd:
+      name: promtail
+      enabled: false
+    register: promtail_disable
+    failed_when: false
+    changed_when: promtail_disable is changed
+  
+  - name: Remove promtail package
+    become: true
+    ansible.builtin.apt:
+      name: promtail
+      state: absent
+      purge: true
+    register: apt_action
+    retries: 100
+    until: apt_action is success or ('Failed to lock apt for exclusive operation' not in apt_action.msg | default('') and '/var/lib/dpkg/lock' not in apt_action.msg | default(''))
+  
+  - name: Remove promtail configuration directory
+    become: true
+    ansible.builtin.file:
+      path: /etc/promtail
+      state: absent
+  
+  - name: Remove promtail log directory
+    become: true
+    ansible.builtin.file:
+      path: /var/log/promtail
+      state: absent
+    when: promtail_remove_log_dir | bool
+  
+  - name: Remove promtail system user
+    become: true
+    ansible.builtin.user:
+      name: promtail
+      state: absent
+      remove: true
+    register: promtail_user_remove
+    failed_when: false
+    changed_when: promtail_user_remove is changed
+  


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new automation that adds an external apt repo/key, installs and manages the `alloy` systemd service, and purges `promtail`; mistakes could disrupt logging on hosts or break package management.
> 
> **Overview**
> Adds a new `alloy` Ansible role that installs Grafana’s apt repo/key and the `alloy` package, templates `/etc/alloy/config.alloy`, optionally deploys extra snippet files, and manages service enablement/start with a restart handler.
> 
> The generated Alloy config forwards syslog, fail2ban, and Chia logs (plus optional extra files) to a configurable Loki endpoint with optional basic auth, and supports appending arbitrary extra River config.
> 
> Adds a `promtail_uninstall` role that stops/disables `promtail`, purges the package, removes `/etc/promtail` (and optionally `/var/log/promtail`), and deletes the `promtail` user.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3a97bae375c08dd1fd2ac2ab3deaae80c58b283. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->