### PR TITLE
Alloy role updates

### DIFF
--- a/alloy/README.md
+++ b/alloy/README.md
@@ -1,0 +1,225 @@
+# Alloy
+
+Installs and configures [Grafana Alloy](https://grafana.com/oss/alloy/) on Debian/Ubuntu hosts to ship logs to a Loki endpoint.
+
+Out of the box the role ships syslog, fail2ban, and Chia logs. You can add
+arbitrary log files, inject raw Alloy config, or deploy extra snippet files for
+full flexibility.
+
+## Requirements
+
+- Debian / Ubuntu target host
+- A reachable Loki push endpoint
+
+## Role Variables
+
+### Alloy core
+
+| Variable | Default | Description |
+|---|---|---|
+| `alloy_log_level` | `info` | Alloy log level (`debug`, `info`, `warn`, `error`). |
+| `alloy_log_format` | `logfmt` | Alloy log format (`logfmt` or `json`). |
+| `alloy_user_groups` | `[adm, systemd-journal, ubuntu]` | Supplementary groups granted to the `alloy` user so it can read log files. |
+| `alloy_start_on_boot` | `true` | Whether the systemd unit is enabled at boot. |
+| `alloy_start_now` | `true` | Start the service immediately (`true`) or leave it stopped (`false`). |
+
+### Loki
+
+| Variable | Default | Description |
+|---|---|---|
+| `loki_endpoint` | `""` | Loki push API URL (e.g. `https://loki.example.com/loki/api/v1/push`). |
+| `loki_basic_auth_username` | `""` | Optional basic-auth username. |
+| `loki_basic_auth_password` | `""` | Optional basic-auth password. |
+
+### Chia
+
+These are applied to the Chia log source and are only relevant if you're
+running Chia.
+
+| Variable | Default | Description |
+|---|---|---|
+| `chia_root` | `/home/ubuntu/.chia` | Path to the Chia root directory. |
+| `application` | `chia-blockchain` | `application` label. |
+| `component` | `node` | `component` label. |
+| `network` | `mainnet` | `network` label. |
+| `group_tag` | `default` | `group` label. |
+| `repo_ref` | `""` | `ref` label (e.g. a git ref). |
+
+### Extensibility
+
+| Variable | Default | Description |
+|---|---|---|
+| `alloy_extra_log_files` | `[]` | List of additional log files to ship (see below). |
+| `alloy_extra_config` | `""` | Raw Alloy (River) config appended to the end of the generated file. |
+| `alloy_additional_files` | `[]` | Extra snippet files deployed to `/etc/alloy/` (see below). |
+
+## Usage Examples
+
+### Minimal – just ship syslog to Loki
+
+```yaml
+- hosts: all
+  roles:
+    - role: alloy
+      loki_endpoint: "https://loki.example.com/loki/api/v1/push"
+```
+
+### Loki with basic auth
+
+```yaml
+- hosts: all
+  roles:
+    - role: alloy
+      loki_endpoint: "https://loki.example.com/loki/api/v1/push"
+      loki_basic_auth_username: "{{ vault_loki_user }}"
+      loki_basic_auth_password: "{{ vault_loki_pass }}"
+```
+
+### Chia with custom labels
+
+```yaml
+- hosts: chia_hosts
+  roles:
+    - role: alloy
+      loki_endpoint: "https://loki.example.com/loki/api/v1/push"
+      application: chia-blockchain
+      component: farmer
+      network: testnet11
+      group_tag: us-east-farm
+      repo_ref: "v2.7.0"
+      chia_root: /opt/chia/.chia
+```
+
+### Ship additional log files
+
+Use `alloy_extra_log_files` to add arbitrary log sources. Each entry creates
+its own `loki.source.file` component forwarding to the default Loki sink.
+
+```yaml
+- hosts: app_servers
+  roles:
+    - role: alloy
+      loki_endpoint: "https://loki.example.com/loki/api/v1/push"
+      alloy_extra_log_files:
+        - name: nginx_access
+          path: /var/log/nginx/access.log
+          job: nginx          # optional – defaults to name
+          extra_labels:        # optional
+            environment: production
+            tier: frontend
+
+        - name: myapp
+          path: /opt/myapp/logs/app.log
+          extra_labels:
+            service: myapp
+```
+
+### Inject raw Alloy config
+
+For components not covered by the built-in scrape targets, append arbitrary
+River config with `alloy_extra_config`.
+
+```yaml
+- hosts: all
+  roles:
+    - role: alloy
+      loki_endpoint: "https://loki.example.com/loki/api/v1/push"
+      alloy_extra_config: |
+        prometheus.scrape "node" {
+          targets    = [{"__address__" = "localhost:9100"}]
+          forward_to = [prometheus.remote_write.default.receiver]
+        }
+
+        prometheus.remote_write "default" {
+          endpoint {
+            url = "https://mimir.example.com/api/v1/push"
+          }
+        }
+```
+
+### Deploy extra snippet files + import them
+
+For larger config blocks, deploy them as separate files with
+`alloy_additional_files` and pull them in via `alloy_extra_config`.
+
+```yaml
+- hosts: all
+  roles:
+    - role: alloy
+      loki_endpoint: "https://loki.example.com/loki/api/v1/push"
+
+      alloy_additional_files:
+        - path: /etc/alloy/metrics.alloy
+          content: |
+            prometheus.scrape "node" {
+              targets    = [{"__address__" = "localhost:9100"}]
+              forward_to = [prometheus.remote_write.default.receiver]
+            }
+
+            prometheus.remote_write "default" {
+              endpoint {
+                url = "https://mimir.example.com/api/v1/push"
+              }
+            }
+
+      alloy_extra_config: |
+        import.file "metrics" {
+          filename = "/etc/alloy/metrics.alloy"
+        }
+```
+
+### Install but don't start
+
+Useful for baking images (AMIs, etc.) where the service should only start once
+the machine is fully provisioned.
+
+```yaml
+- hosts: packer_builders
+  roles:
+    - role: alloy
+      loki_endpoint: "https://loki.example.com/loki/api/v1/push"
+      alloy_start_now: false
+      alloy_start_on_boot: true
+```
+
+### Grant extra groups for log access
+
+If your application writes logs as a specific group, add that group so the
+`alloy` user can read them.
+
+```yaml
+- hosts: app_servers
+  roles:
+    - role: alloy
+      loki_endpoint: "https://loki.example.com/loki/api/v1/push"
+      alloy_user_groups:
+        - adm
+        - systemd-journal
+        - ubuntu
+        - myapp-logs
+```
+
+## What Gets Deployed
+
+| Path | Description |
+|---|---|
+| `/etc/alloy/config.alloy` | Main Alloy configuration (templated). |
+| `/etc/alloy/*.alloy` | Any additional snippet files from `alloy_additional_files`. |
+| `/usr/share/keyrings/grafana.gpg` | Grafana APT signing key. |
+
+The role enables the `alloy` systemd unit and (by default) starts it
+immediately. A handler restarts the service whenever the config or snippet
+files change.
+
+## Built-in Log Sources
+
+The generated config always includes these `loki.source.file` components:
+
+| Name | Path | Job label |
+|---|---|---|
+| `syslog` | `/var/log/syslog` | `syslog` |
+| `fail2ban` | `/var/log/fail2ban.log` | `fail2ban` |
+| `chia` | `{{ chia_root }}/log/debug.log` | `chia` |
+
+The Chia source passes through a `loki.process` stage that handles multiline
+log entries and JSON field extraction before forwarding to Loki.

--- a/alloy/tasks/main.yml
+++ b/alloy/tasks/main.yml
@@ -33,7 +33,8 @@
   become: true
   ansible.builtin.command:
     cmd: gpg --batch --yes --dearmor -o /usr/share/keyrings/grafana.gpg /tmp/grafana.key
-  when: grafana_key_download.changed
+    creates: /usr/share/keyrings/grafana.gpg
+  when: grafana_key_download.changed or not grafana_gpg_keyring.stat.exists
 
 - name: Add Grafana apt repository
   become: true

--- a/alloy/tasks/main.yml
+++ b/alloy/tasks/main.yml
@@ -29,11 +29,15 @@
     mode: '0644'
   register: grafana_key_download
 
+- name: Check whether keyring already exists
+  ansible.builtin.stat:
+    path: /usr/share/keyrings/grafana.gpg
+  register: grafana_gpg_keyring
+
 - name: Convert to keyring format
   become: true
   ansible.builtin.command:
     cmd: gpg --batch --yes --dearmor -o /usr/share/keyrings/grafana.gpg /tmp/grafana.key
-    creates: /usr/share/keyrings/grafana.gpg
   when: grafana_key_download.changed or not grafana_gpg_keyring.stat.exists
 
 - name: Add Grafana apt repository

--- a/alloy/tasks/main.yml
+++ b/alloy/tasks/main.yml
@@ -21,12 +21,19 @@
     state: directory
     mode: '0755'
 
-- name: Download Grafana GPG key
+- name: Download Grafana GPG key (ASCII)
   become: true
-  ansible.builtin.apt_key:
+  ansible.builtin.get_url:
     url: https://apt.grafana.com/gpg.key
-    state: present
-    keyring: /usr/share/keyrings/grafana.gpg
+    dest: /tmp/grafana.key
+    mode: '0644'
+
+- name: Convert to keyring format
+  become: true
+  ansible.builtin.command:
+    cmd: gpg --dearmor -o /usr/share/keyrings/grafana.gpg /tmp/grafana.key
+  args:
+    creates: /usr/share/keyrings/grafana.gpg
 
 - name: Add Grafana apt repository
   become: true

--- a/alloy/tasks/main.yml
+++ b/alloy/tasks/main.yml
@@ -32,7 +32,7 @@
 - name: Convert to keyring format
   become: true
   ansible.builtin.command:
-    cmd: gpg --dearmor -o /usr/share/keyrings/grafana.gpg /tmp/grafana.key
+    cmd: gpg --batch --yes --dearmor -o /usr/share/keyrings/grafana.gpg /tmp/grafana.key
   when: grafana_key_download.changed
 
 - name: Add Grafana apt repository

--- a/alloy/tasks/main.yml
+++ b/alloy/tasks/main.yml
@@ -27,13 +27,13 @@
     url: https://apt.grafana.com/gpg.key
     dest: /tmp/grafana.key
     mode: '0644'
+  register: grafana_key_download
 
 - name: Convert to keyring format
   become: true
   ansible.builtin.command:
     cmd: gpg --dearmor -o /usr/share/keyrings/grafana.gpg /tmp/grafana.key
-  args:
-    creates: /usr/share/keyrings/grafana.gpg
+  when: grafana_key_download.changed
 
 - name: Add Grafana apt repository
   become: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how the Grafana APT signing key is installed (download + `gpg --dearmor`), which could break package installs on hosts if the key conversion/path behaves differently or `/tmp` handling is restricted.
> 
> **Overview**
> Adds a new `alloy/README.md` documenting the Alloy Ansible role (variables, Loki auth options, extensibility, and usage examples).
> 
> Updates the role’s Grafana APT key setup to download the ASCII key and explicitly convert it into `/usr/share/keyrings/grafana.gpg` via `gpg --dearmor`, gated by a `stat` check, replacing the prior `apt_key` approach.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21d6bf61da98b4fc5aa025cc627f505c28f65209. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->