### PR TITLE
Add knobs to opt out of builtin Alloy sources

### DIFF
--- a/alloy/README.md
+++ b/alloy/README.md
@@ -2,9 +2,10 @@
 
 Installs and configures [Grafana Alloy](https://grafana.com/oss/alloy/) on Debian/Ubuntu hosts to ship logs to a Loki endpoint.
 
-Out of the box the role ships syslog, fail2ban, and Chia logs. You can add
-arbitrary log files, inject raw Alloy config, or deploy extra snippet files for
-full flexibility.
+The role includes opt-out scrape configs for syslog, fail2ban, and Chia logs.
+Disable any of them with the `alloy_enable_*_source` flags below. You can also
+add arbitrary log files, inject raw Alloy config, or deploy extra snippet files
+for full flexibility.
 
 ## Requirements
 
@@ -31,10 +32,21 @@ full flexibility.
 | `loki_basic_auth_username` | `""` | Optional basic-auth username. |
 | `loki_basic_auth_password` | `""` | Optional basic-auth password. |
 
+### Built-in log sources
+
+All built-in sources are opt-out. Set the corresponding flag to `false` to
+exclude the source in the generated config.
+
+| Variable | Default | Description |
+|---|---------|---|
+| `alloy_enable_syslog_source` | `true`  | Ship `/var/log/syslog` to Loki. |
+| `alloy_enable_fail2ban_source` | `true` | Ship `/var/log/fail2ban.log` to Loki. |
+| `alloy_enable_chia_source` | `true` | Ship Chia debug logs (with multiline + JSON processing). |
+
 ### Chia
 
-These are applied to the Chia log source and are only relevant if you're
-running Chia.
+These are applied to the Chia log source and are only relevant when
+`alloy_enable_chia_source` is `true`.
 
 | Variable | Default | Description |
 |---|---|---|
@@ -213,13 +225,14 @@ files change.
 
 ## Built-in Log Sources
 
-The generated config always includes these `loki.source.file` components:
+The role can generate `loki.source.file` components for these log files. Each
+is opt-out (enabled by default) via the corresponding flag.
 
-| Name | Path | Job label |
-|---|---|---|
-| `syslog` | `/var/log/syslog` | `syslog` |
-| `fail2ban` | `/var/log/fail2ban.log` | `fail2ban` |
-| `chia` | `{{ chia_root }}/log/debug.log` | `chia` |
+| Name | Enable flag | Path | Job label |
+|---|---|---|---|
+| `syslog` | `alloy_enable_syslog_source` | `/var/log/syslog` | `syslog` |
+| `fail2ban` | `alloy_enable_fail2ban_source` | `/var/log/fail2ban.log` | `fail2ban` |
+| `chia` | `alloy_enable_chia_source` | `{{ chia_root }}/log/debug.log` | `chia` |
 
 The Chia source passes through a `loki.process` stage that handles multiline
 log entries and JSON field extraction before forwarding to Loki.

--- a/alloy/defaults/main.yml
+++ b/alloy/defaults/main.yml
@@ -13,7 +13,12 @@ loki_endpoint: ""
 loki_basic_auth_username: ""
 loki_basic_auth_password: ""
 
-# Chia log labels
+# Built-in log sources (opt-out)
+alloy_enable_syslog_source: true
+alloy_enable_fail2ban_source: true
+alloy_enable_chia_source: true
+
+# Chia log labels (only used when alloy_enable_chia_source is true)
 application: "chia-blockchain"
 component: "node"
 network: "mainnet"

--- a/alloy/templates/config.alloy.j2
+++ b/alloy/templates/config.alloy.j2
@@ -19,6 +19,7 @@ loki.write "default" {
   }
 }
 
+{% if alloy_enable_syslog_source %}
 // ── Syslog ───────────────────────────────────────────────────────────────────
 
 loki.source.file "syslog" {
@@ -31,6 +32,8 @@ loki.source.file "syslog" {
   ]
   forward_to = [loki.write.default.receiver]
 }
+{% endif %}
+{% if alloy_enable_fail2ban_source %}
 
 // ── Fail2ban ─────────────────────────────────────────────────────────────────
 
@@ -44,6 +47,8 @@ loki.source.file "fail2ban" {
   ]
   forward_to = [loki.write.default.receiver]
 }
+{% endif %}
+{% if alloy_enable_chia_source %}
 
 // ── Chia ─────────────────────────────────────────────────────────────────────
 
@@ -79,6 +84,7 @@ loki.process "chia" {
 
   forward_to = [loki.write.default.receiver]
 }
+{% endif %}
 
 // ── Extra log files ──────────────────────────────────────────────────────────
 {% for extra in alloy_extra_log_files %}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: change is limited to templating/role defaults and only affects which built-in `loki.source.file` blocks are rendered; defaults preserve existing behavior.
> 
> **Overview**
> Adds opt-out toggles for the role’s built-in log sources by introducing `alloy_enable_syslog_source`, `alloy_enable_fail2ban_source`, and `alloy_enable_chia_source` (default `true`).
> 
> Updates `config.alloy.j2` to conditionally render the syslog/fail2ban/chia `loki.source.file` (and Chia `loki.process`) blocks based on these flags, and updates the README to document the new variables and clarify Chia settings apply only when the Chia source is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7a47fea97acb1d5af96787338071e6923e9df53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->