### PR TITLE
Add the ability to configure additional fail2ban jail.d configurations

### DIFF
--- a/fail2ban/defaults/main.yml
+++ b/fail2ban/defaults/main.yml
@@ -6,3 +6,27 @@ fail2ban_ignoreip: 127.0.0.1/8 ::1
 fail2ban_bantime: 10m
 fail2ban_findtime: 10m
 fail2ban_maxretry: 5
+
+# Arbitrary jail configs dropped into /etc/fail2ban/jail.d/<name>.local.
+# Each top-level key is the jail name (used as both the [section] header and
+# the filename). Values are dicts of option/value pairs rendered as INI.
+#
+# Example:
+#   fail2ban_jails:
+#     sshd:
+#       enabled: true
+#       port: ssh
+#       filter: sshd
+#       logpath: /var/log/auth.log
+#       maxretry: 3
+#     nginx-http-auth:
+#       enabled: true
+#       port: "http,https"
+#       filter: nginx-http-auth
+#       logpath: /var/log/nginx/error.log
+fail2ban_jails: {}
+
+# When true, any *.local file in /etc/fail2ban/jail.d/ that is not declared in
+# fail2ban_jails is removed. Leave false to coexist with files managed
+# elsewhere.
+fail2ban_jails_purge: false

--- a/fail2ban/handlers/main.yml
+++ b/fail2ban/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Restart fail2ban
+  become: true
+  ansible.builtin.systemd:
+    name: fail2ban
+    state: restarted
+  when: fail2ban_start_now

--- a/fail2ban/tasks/main.yml
+++ b/fail2ban/tasks/main.yml
@@ -66,7 +66,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: absent
-  loop: "{{ fail2ban_existing_jails.files }}"
+  loop: "{{ fail2ban_existing_jails.files | default([]) }}"
   loop_control:
     label: "{{ item.path }}"
   when:

--- a/fail2ban/tasks/main.yml
+++ b/fail2ban/tasks/main.yml
@@ -25,3 +25,51 @@
     src: jail.local.j2
     dest: "/etc/fail2ban/jail.local"
     mode: '0644'
+  notify: Restart fail2ban
+
+- name: Ensure jail.d directory exists
+  become: true
+  ansible.builtin.file:
+    path: /etc/fail2ban/jail.d
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+
+- name: Add per-service jail configs
+  become: true
+  ansible.builtin.template:
+    src: jail.d.local.j2
+    dest: "/etc/fail2ban/jail.d/{{ item.key }}.local"
+    owner: root
+    group: root
+    mode: '0644'
+  vars:
+    jail_name: "{{ item.key }}"
+    jail_options: "{{ item.value }}"
+  loop: "{{ fail2ban_jails | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+  notify: Restart fail2ban
+
+- name: Find existing jail.d drop-ins
+  become: true
+  ansible.builtin.find:
+    paths: /etc/fail2ban/jail.d
+    patterns: "*.local"
+    file_type: file
+  register: fail2ban_existing_jails
+  when: fail2ban_jails_purge
+
+- name: Remove jail.d drop-ins not declared in fail2ban_jails
+  become: true
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: absent
+  loop: "{{ fail2ban_existing_jails.files }}"
+  loop_control:
+    label: "{{ item.path }}"
+  when:
+    - fail2ban_jails_purge
+    - (item.path | basename | splitext | first) not in (fail2ban_jails.keys() | list)
+  notify: Restart fail2ban

--- a/fail2ban/templates/jail.d.local.j2
+++ b/fail2ban/templates/jail.d.local.j2
@@ -1,0 +1,6 @@
+{# Renders a single jail drop-in. `jail_name` and `jail_options` are passed
+   in via template vars. #}
+[{{ jail_name }}]
+{% for key, value in jail_options.items() %}
+{{ key }} = {{ value }}
+{% endfor %}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds dynamic generation (and optional purging) of `/etc/fail2ban/jail.d/*.local` files, which can materially change banning behavior and potentially lock out access if misconfigured.
> 
> **Overview**
> Adds variable-driven management of additional Fail2Ban jails by rendering per-jail drop-ins into `/etc/fail2ban/jail.d/<name>.local` from the new `fail2ban_jails` map.
> 
> Introduces a `Restart fail2ban` handler and wires notifications from `jail.local` and the new drop-in templates; optionally purges undeclared `jail.d/*.local` files when `fail2ban_jails_purge: true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dffeefad3a775db930ddd9749f5ca939384673d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->