### PR TITLE
Add apt-unlock role for killing zombie unattended-upgrades apt locks

### DIFF
--- a/apt-unlock/defaults/main.yml
+++ b/apt-unlock/defaults/main.yml
@@ -1,0 +1,31 @@
+---
+# Minimum elapsed wall time (seconds) before an apt-related process is
+# considered stale. 2h is comfortably longer than any legitimate apt run.
+apt_unlock_min_age_seconds: 7200
+
+# Process "Name" (from /proc/<pid>/status) prefixes we are willing to kill.
+# Matched as a prefix so the 15-char-truncated kernel comm still matches
+# (e.g. "unattended-upgr" is the truncated form of "unattended-upgrade").
+apt_unlock_allowed_process_names:
+  - unattended-upgr
+  - unattended-upgrade
+  - apt
+  - apt-get
+  - dpkg
+  - aptitude
+
+# Process states considered stuck. Deliberately excludes R (actively running).
+# S=interruptible sleep, D=uninterruptible sleep, Z=zombie, T=stopped.
+apt_unlock_killable_states: [S, D, Z, T]
+
+apt_unlock_lock_files:
+  - /var/lib/dpkg/lock
+  - /var/lib/dpkg/lock-frontend
+  - /var/cache/apt/archives/lock
+  - /var/lib/apt/lists/lock
+
+apt_unlock_run_dpkg_configure: true
+apt_unlock_run_apt_check: true
+
+# Seconds to wait after SIGKILL for the kernel to release fcntl locks.
+apt_unlock_post_kill_wait: 5

--- a/apt-unlock/tasks/main.yml
+++ b/apt-unlock/tasks/main.yml
@@ -1,0 +1,91 @@
+---
+- name: Detect stale apt lock holders
+  become: true
+  ansible.builtin.shell: |
+    set -u
+    MIN_AGE={{ apt_unlock_min_age_seconds }}
+    ALLOWED_NAMES="{{ apt_unlock_allowed_process_names | join(' ') }}"
+    KILLABLE_STATES="{{ apt_unlock_killable_states | join('') }}"
+    LOCK_FILES="{{ apt_unlock_lock_files | join(' ') }}"
+
+    pids=""
+    for f in $LOCK_FILES; do
+      [ -e "$f" ] || continue
+      holders=$(fuser "$f" 2>/dev/null || true)
+      [ -n "$holders" ] && pids="$pids $holders"
+    done
+    pids=$(printf '%s\n' $pids | sed '/^$/d' | sort -u)
+    [ -z "$pids" ] && exit 0
+
+    for pid in $pids; do
+      [ -r /proc/$pid/status ] || continue
+      name=$(awk '/^Name:/ {print $2; exit}' /proc/$pid/status)
+      state=$(awk '/^State:/ {print $2; exit}' /proc/$pid/status)
+      etime=$(ps -o etimes= -p "$pid" 2>/dev/null | tr -d ' ')
+      [ -n "$name" ] || continue
+      [ -n "$state" ] || continue
+      [ -n "$etime" ] || continue
+
+      name_allowed=0
+      for allowed in $ALLOWED_NAMES; do
+        case "$name" in
+          "$allowed"|"$allowed"*) name_allowed=1; break ;;
+        esac
+      done
+      [ "$name_allowed" = "1" ] || continue
+
+      case "$KILLABLE_STATES" in
+        *"$state"*) ;;
+        *) continue ;;
+      esac
+
+      [ "$etime" -ge "$MIN_AGE" ] || continue
+
+      echo "${pid}:${name}:${state}:${etime}"
+    done
+  args:
+    executable: /bin/bash
+  register: apt_unlock_stale
+  changed_when: false
+
+- name: Report stale apt lock holders to be killed
+  ansible.builtin.debug:
+    msg: "Killing stale apt lock holder: {{ item }}"
+  loop: "{{ apt_unlock_stale.stdout_lines }}"
+  when: apt_unlock_stale.stdout_lines | length > 0
+
+- name: Kill stale apt lock holders
+  become: true
+  ansible.builtin.command: "kill -9 {{ item.split(':')[0] }}"
+  loop: "{{ apt_unlock_stale.stdout_lines }}"
+  when: apt_unlock_stale.stdout_lines | length > 0
+
+- name: Wait for kernel to release apt locks
+  ansible.builtin.pause:
+    seconds: "{{ apt_unlock_post_kill_wait }}"
+  when: apt_unlock_stale.stdout_lines | length > 0
+
+- name: Remove residual apt lock files
+  become: true
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop: "{{ apt_unlock_lock_files }}"
+  when: apt_unlock_stale.stdout_lines | length > 0
+
+- name: Recover dpkg state after killing stale holders
+  become: true
+  ansible.builtin.command: dpkg --configure -a
+  register: apt_unlock_dpkg_configure
+  changed_when: apt_unlock_dpkg_configure.stdout | trim | length > 0
+  when:
+    - apt_unlock_stale.stdout_lines | length > 0
+    - apt_unlock_run_dpkg_configure | bool
+
+- name: Sanity-check apt after unlock
+  become: true
+  ansible.builtin.command: apt-get check
+  changed_when: false
+  when:
+    - apt_unlock_stale.stdout_lines | length > 0
+    - apt_unlock_run_apt_check | bool


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Automates `SIGKILL` of processes holding apt/dpkg locks and removes lock files, which could disrupt legitimate package operations if the staleness detection is wrong. Safeguards (min-age, allowed process names, and killable states) reduce but don’t eliminate the risk.
> 
> **Overview**
> Adds a new Ansible role `apt-unlock` that detects PIDs holding common apt/dpkg lock files and treats them as *stale* only if they match an allowlist of apt-related process names, are in specific non-running states, and exceed a configurable minimum age.
> 
> When stale holders are found, the role logs what will be killed, issues `kill -9`, waits briefly for locks to clear, removes residual lock files, and optionally runs `dpkg --configure -a` plus `apt-get check` to recover and validate the package manager state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8f70fcf6898ab03784e5b102c052eef351580ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->