### PR TITLE
Add flags to toggle base-setup tasks

### DIFF
--- a/base-setup/defaults/main.yml
+++ b/base-setup/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+base_setup_disable_ssh_password_login: true
+base_setup_disable_ssh_root_login: true

--- a/base-setup/readme.md
+++ b/base-setup/readme.md
@@ -1,3 +1,10 @@
 # Base Setup
 
 Applies some common settings to all systems
+
+## Variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `base_setup_disable_ssh_password_login` | `true` | When true, sets `PasswordAuthentication no` in `/etc/ssh/sshd_config`. |
+| `base_setup_disable_ssh_root_login` | `true` | When true, sets `PermitRootLogin no` in `/etc/ssh/sshd_config`. |

--- a/base-setup/tasks/main.yml
+++ b/base-setup/tasks/main.yml
@@ -6,6 +6,7 @@
     regexp: '^PasswordAuthentication'
     line: "PasswordAuthentication no"
   notify: restart-ssh
+  when: base_setup_disable_ssh_password_login | bool
 
 - name: Disable root login for SSH
   become: true
@@ -14,3 +15,4 @@
     regexp: '^PermitRootLogin'
     line: "PermitRootLogin no"
   notify: restart-ssh
+  when: base_setup_disable_ssh_root_login | bool


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk since defaults preserve current SSH-hardening behavior; the main risk is misconfiguration if a caller sets the new flags to `false`, leaving password or root SSH login enabled.
> 
> **Overview**
> Adds two new `base-setup` variables (`base_setup_disable_ssh_password_login` and `base_setup_disable_ssh_root_login`, defaulting to `true`) and gates the corresponding `sshd_config` `lineinfile` tasks with `when` conditions.
> 
> Updates `base-setup/readme.md` to document the new toggles and their effect on `PasswordAuthentication` and `PermitRootLogin`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8f8b07355a6ff706cf11266d9d908a758e87323. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->