### PR TITLE
Update smartctl_exporter to 0.14.0

### DIFF
--- a/smartctl-exporter/defaults/main.yml
+++ b/smartctl-exporter/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
-smartctl_exporter_version: "0.13.0"
+smartctl_exporter_version: "0.14.0"
 smartctl_exporter_port: 9633
 smartctl_exporter_args: ""


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk change that only bumps the default `smartctl_exporter_version`; deployment behavior changes only insofar as the newer upstream exporter release differs.
> 
> **Overview**
> Updates the Ansible role default `smartctl_exporter_version` from `0.13.0` to `0.14.0`, causing deployments that rely on defaults to install/roll out the newer smartctl-exporter release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5979ff0fe35560ea08dac7b01700cdc3793dd992. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->