### PR TITLE
Migrate roles to new apt keyring pattern

### DIFF
--- a/chia-apt-key/tasks/main.yml
+++ b/chia-apt-key/tasks/main.yml
@@ -13,9 +13,28 @@
   retries: 100
   until: apt_action is success or ('Failed to lock apt for exclusive operation' not in apt_action.msg and '/var/lib/dpkg/lock' not in apt_action.msg)
 
-- name: Get chia key
+- name: Ensure apt keyrings directory exists
   become: true
-  ansible.builtin.apt_key:
+  ansible.builtin.file:
+    path: /usr/share/keyrings
+    state: directory
+    mode: '0755'
+
+- name: Download Chia GPG key (ASCII)
+  become: true
+  ansible.builtin.get_url:
     url: https://repo.chia.net/FD39E6D3.pubkey.asc
-    state: present
-    keyring: /usr/share/keyrings/chia.gpg
+    dest: /tmp/chia.key
+    mode: '0644'
+  register: chia_key_download
+
+- name: Check whether keyring already exists
+  ansible.builtin.stat:
+    path: /usr/share/keyrings/chia.gpg
+  register: chia_gpg_keyring
+
+- name: Convert to keyring format
+  become: true
+  ansible.builtin.command:
+    cmd: gpg --batch --yes --dearmor -o /usr/share/keyrings/chia.gpg /tmp/chia.key
+  when: chia_key_download.changed or not chia_gpg_keyring.stat.exists

--- a/hashi/defaults/main.yml
+++ b/hashi/defaults/main.yml
@@ -1,0 +1,36 @@
+---
+# HashiCorp's apt repo only publishes the upstream Debian/Ubuntu codenames
+# (noble, jammy, bookworm, trixie, ...). Derivatives (Mint, Pop!_OS, Zorin,
+# Proxmox templates with custom VERSION_CODENAME, etc.) and brand-new releases
+# that HashiCorp hasn't packaged for yet report codenames that don't exist at
+# apt.releases.hashicorp.com, e.g. "resolute" (Ubuntu 26.04 LTS).
+#
+# We map well-known families/versions to the upstream codename, and fall back
+# to ansible_distribution_release otherwise. Override per-host if needed:
+#   hashi_repo_codename: noble
+#
+# When HashiCorp publishes a previously-missing codename (verify with e.g.
+# `curl -fsI https://apt.releases.hashicorp.com/dists/resolute/InRelease` —
+# a 200 means it's live), drop the corresponding entry from the map so the
+# fallback picks up ansible_distribution_release on its own.
+hashi_codename_map:
+  Debian:
+    "11": bullseye
+    "12": bookworm
+    "13": trixie
+  Ubuntu:
+    "20": focal
+    "22": jammy
+    "24": noble
+    "25": questing
+    # 26.04 (resolute) has no HashiCorp repo yet; fall back to the latest LTS.
+    # HashiCorp ships static Go binaries, so noble packages run fine on 26.04.
+    "26": noble
+
+hashi_repo_codename: >-
+  {{
+    hashi_codename_map.get(ansible_distribution, {}).get(
+      ansible_distribution_major_version | string,
+      ansible_distribution_release
+    )
+  }}

--- a/hashi/defaults/main.yml
+++ b/hashi/defaults/main.yml
@@ -22,7 +22,6 @@ hashi_codename_map:
     "20": focal
     "22": jammy
     "24": noble
-    "25": questing
     # 26.04 (resolute) has no HashiCorp repo yet; fall back to the latest LTS.
     # HashiCorp ships static Go binaries, so noble packages run fine on 26.04.
     "26": noble

--- a/hashi/tasks/main.yml
+++ b/hashi/tasks/main.yml
@@ -52,5 +52,5 @@
 - name: Add HashiCorp apt repository
   become: true
   ansible.builtin.apt_repository:
-    repo: "deb [arch={{ hashi_repo_arch }} signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com {{ ansible_distribution_release }} main"
+    repo: "deb [arch={{ hashi_repo_arch }} signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com {{ hashi_repo_codename | trim }} main"
     filename: hashicorp

--- a/hashi/tasks/main.yml
+++ b/hashi/tasks/main.yml
@@ -4,15 +4,53 @@
   vars:
     params:
       files:
-        - '{{ansible_architecture}}.yml'
+        - '{{ ansible_architecture }}.yml'
       paths:
         - 'vars'
 
-- name: Get hashicorp key
-  ansible.builtin.apt_key:
-    url: https://apt.releases.hashicorp.com/gpg
+- name: Install deps
+  become: true
+  ansible.builtin.apt:
+    name:
+      - apt-transport-https
+      - curl
+      - gnupg
+      - python3-apt
     state: present
+    update_cache: true
+    cache_valid_time: 300
+  register: apt_action
+  retries: 100
+  until: apt_action is success or ('Failed to lock apt for exclusive operation' not in apt_action.msg | default('') and '/var/lib/dpkg/lock' not in apt_action.msg | default(''))
 
-- name: Hashicorp repository
+- name: Ensure apt keyrings directory exists
+  become: true
+  ansible.builtin.file:
+    path: /usr/share/keyrings
+    state: directory
+    mode: '0755'
+
+- name: Download HashiCorp GPG key (ASCII)
+  become: true
+  ansible.builtin.get_url:
+    url: https://apt.releases.hashicorp.com/gpg
+    dest: /tmp/hashicorp.key
+    mode: '0644'
+  register: hashicorp_key_download
+
+- name: Check whether HashiCorp keyring already exists
+  ansible.builtin.stat:
+    path: /usr/share/keyrings/hashicorp-archive-keyring.gpg
+  register: hashicorp_gpg_keyring
+
+- name: Convert HashiCorp key to keyring format
+  become: true
+  ansible.builtin.command:
+    cmd: gpg --batch --yes --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg /tmp/hashicorp.key
+  when: hashicorp_key_download.changed or not hashicorp_gpg_keyring.stat.exists
+
+- name: Add HashiCorp apt repository
+  become: true
   ansible.builtin.apt_repository:
-    repo: deb [arch={{ hashi_repo_arch }}] https://apt.releases.hashicorp.com {{ ansible_distribution_release }} main
+    repo: "deb [arch={{ hashi_repo_arch }} signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com {{ ansible_distribution_release }} main"
+    filename: hashicorp

--- a/promtail/tasks/main.yml
+++ b/promtail/tasks/main.yml
@@ -29,12 +29,24 @@
     group: adm
     mode: '0775'
 
-- name: Download Grafana GPG key
+- name: Download Grafana GPG key (ASCII)
   become: true
-  ansible.builtin.apt_key:
+  ansible.builtin.get_url:
     url: https://apt.grafana.com/gpg.key
-    state: present
-    keyring: /usr/share/keyrings/grafana.gpg
+    dest: /tmp/grafana.key
+    mode: '0644'
+  register: grafana_key_download
+
+- name: Check whether keyring already exists
+  ansible.builtin.stat:
+    path: /usr/share/keyrings/grafana.gpg
+  register: grafana_gpg_keyring
+
+- name: Convert to keyring format
+  become: true
+  ansible.builtin.command:
+    cmd: gpg --batch --yes --dearmor -o /usr/share/keyrings/grafana.gpg /tmp/grafana.key
+  when: grafana_key_download.changed or not grafana_gpg_keyring.stat.exists
 
 - name: Add Grafana apt repository
   become: true

--- a/vector/tasks/main.yml
+++ b/vector/tasks/main.yml
@@ -14,12 +14,31 @@
   retries: 100
   until: apt_action is success or ('Failed to lock apt for exclusive operation' not in apt_action.msg and '/var/lib/dpkg/lock' not in apt_action.msg)
 
-- name: Add vector key
-  become: yes
-  ansible.builtin.apt_key:
+- name: Ensure apt keyrings directory exists
+  become: true
+  ansible.builtin.file:
+    path: /usr/share/keyrings
+    state: directory
+    mode: '0755'
+
+- name: Download vector signing key (ASCII)
+  become: true
+  ansible.builtin.get_url:
     url: https://keys.datadoghq.com/DATADOG_APT_KEY_CURRENT.public
-    state: present
-    keyring: /usr/share/keyrings/datadog-archive-keyring.gpg
+    dest: /tmp/datadog-archive-keyring.key
+    mode: '0644'
+  register: vector_key_download
+
+- name: Check whether keyring already exists
+  ansible.builtin.stat:
+    path: /usr/share/keyrings/datadog-archive-keyring.gpg
+  register: vector_gpg_keyring
+
+- name: Convert to keyring format
+  become: true
+  ansible.builtin.command:
+    cmd: gpg --batch --yes --dearmor -o /usr/share/keyrings/datadog-archive-keyring.gpg /tmp/datadog-archive-keyring.key
+  when: vector_key_download.changed or not vector_gpg_keyring.stat.exists
 
 - name: Add vector repository
   become: yes


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how apt repositories are trusted and configured across several roles; misconfiguration could break package installs or trust the wrong key/codename on affected hosts.
> 
> **Overview**
> Migrates the `chia-apt-key`, `promtail`, and `vector` roles from `apt_key` to the modern *signed-by keyring* flow by ensuring `/usr/share/keyrings` exists, downloading ASCII GPG keys to `/tmp`, and converting them with `gpg --dearmor` only when needed.
> 
> Updates the `hashi` role to follow the same keyring pattern, adds apt dependency installation with retry-on-lock behavior, and changes the HashiCorp `apt_repository` entry to use `signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg`.
> 
> Adds `hashi/defaults/main.yml` to map Debian/Ubuntu major versions to upstream HashiCorp-supported codenames (e.g., Ubuntu 26 -> `noble`) so installs work on derivatives/new releases where `ansible_distribution_release` may not exist in the HashiCorp repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25c63321e33667729c05eae47ba7b6bdd8eae614. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->