### PR TITLE
Update default vault version to 2.0.3

### DIFF
--- a/vault/defaults/main.yml
+++ b/vault/defaults/main.yml
@@ -2,7 +2,7 @@
 vault_start_on_boot: yes
 vault_start_now: yes
 
-vault_version: 1.21.4-1
+vault_version: 2.0.3-1
 
 vault_api_addr: "https://vault.example.com:8200"
 vault_cluster_addr: "http://10.11.12.13:8201"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Defaulting new deployments to Vault 2.x is a major-version jump that can surface upgrade/breaking-change concerns for environments that don’t override `vault_version`.
> 
> **Overview**
> Updates the Ansible role default **`vault_version`** from `1.21.4-1` to `2.0.3-1` in `vault/defaults/main.yml`.
> 
> That default pins the package version used when the role installs Vault via `apt` (`vault={{ vault_version }}`), so playbooks that rely on the default will target Vault **2.0.3** instead of **1.21.4**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5715380a060811fb61775216d84a1124955da6f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->