### PR TITLE
Update vault to 2.0.4

### DIFF
--- a/vault/defaults/main.yml
+++ b/vault/defaults/main.yml
@@ -2,7 +2,7 @@
 vault_start_on_boot: yes
 vault_start_now: yes
 
-vault_version: 2.0.3-1
+vault_version: 2.0.4-1
 
 vault_api_addr: "https://vault.example.com:8200"
 vault_cluster_addr: "http://10.11.12.13:8201"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Upgrading Vault on deployed nodes can affect secrets storage and cluster behavior; scope is limited to the default pin with no other role changes in this PR.
> 
> **Overview**
> Bumps the Ansible role default **`vault_version`** from `2.0.3-1` to `2.0.4-1`, so installs and upgrades via the existing `apt` task target the newer HashiCorp Vault release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4db522e29335e28d50f10d86b73ea2073349355. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->